### PR TITLE
Fix rounding errors in KNX plugin when converting from/to DPT 5.001

### DIFF
--- a/plugins/knx/dpts.py
+++ b/plugins/knx/dpts.py
@@ -83,13 +83,13 @@ def de5(payload):
 
 
 def en5001(value):
-    return [0, int(int(value) * 255 / 100) & 0xff]
+    return [0, int(value * 255.0 / 100) & 0xff]
 
 
 def de5001(payload):
     if len(payload) != 1:
         return None
-    return struct.unpack('>B', payload)[0] * 100 / 255
+    return struct.unpack('>B', payload)[0] * 100.0 / 255
 
 
 def en6(value):


### PR DESCRIPTION
Hi Marcus,

I really think we should treat DPT 5.001 as a float when converting not to loose precision. We are converting from 0...255 to 0....100. Even if we round correctly we end up loosing precision, which might be fatal in certain cases. As other DPTs are treated as floats anyway there is not additional work to do.
