### PR TITLE
New plugin for KOSTAL inverter modules

### DIFF
--- a/plugins/kostal/README.md
+++ b/plugins/kostal/README.md
@@ -102,7 +102,7 @@ daily power. Additionally it shows the volts and watts for the phases.
 
 No logic related stuff implemented.
 
-# Methodes
+# Methods
 
 No methods provided currently.
 

--- a/plugins/kostal/README.md
+++ b/plugins/kostal/README.md
@@ -6,7 +6,7 @@ summary: Retrieve data from a KOSTAL inverter module
 
 # Requirements
 
-This plugin is designed to retrieve data from a KOSTAL inverter module (e.g. PICO inverters).
+This plugin is designed to retrieve data from a [KOSTAL](http://www.kostal-solar-electric.com/) inverter module (e.g. PICO inverters).
 
 ## Supported Hardware
 
@@ -18,7 +18,7 @@ Is currently working with the following KOSTA inverter modules:
 
 ## plugin.conf
 
-Please provide a plugin.conf snippet for your plugin with ever option your plugin supports. Optional attributes should be commented out.
+The plugin can be configured like this:
 
 <pre>
 [KOSTAL]
@@ -60,26 +60,49 @@ following list of information can be specified:
 
 ### Example
 
-Please provide an item configuration with every attribute and usefull settings.
+Example configuration which shows the current status and the current, total and
+daily power. Additionally it shows the volts and watts for the phases.
 
 <pre>
 # items/my.conf
-
 [solar]
+    [[status]]
+        type = str
+        kostal = status
     [[current]]
         type = num
-        kostal = 1
+        kostal = power_current
+    [[total]]
+        type = num
+        kostal = power_total
+    [[day]]
+        type = num
+        kostal = power_day
+    [[l1v]]
+        type = num
+        kostal = l1_watt
+    [[l1w]]
+        type = num
+        kostal = l1_watt
+    [[l2v]]
+        type = num
+        kostal = l2_watt
+    [[l2w]]
+        type = num
+        kostal = l2_watt
+    [[l3v]]
+        type = num
+        kostal = l3_watt
+    [[l3w]]
+        type = num
+        kostal = l3_watt
 </pre>
 
 ## logic.conf
-If your plugin support item triggers as well, please describe the attributes like the item attributes.
 
+No logic related stuff implemented.
 
 # Methodes
-If your plugin provides methods for logics. List and describe them here...
 
-## method1(param1, param2)
-This method enables the logic to send param1 and param2 to the device. You could call it with `sh.my.method1('String', 2)`.
+No methods provided currently.
 
-## method2()
-This method does nothing.

--- a/plugins/kostal/README.md
+++ b/plugins/kostal/README.md
@@ -1,0 +1,85 @@
+---
+title: KOSTAL plugin
+layout: default
+summary: Retrieve data from a KOSTAL inverter module
+---
+
+# Requirements
+
+This plugin is designed to retrieve data from a KOSTAL inverter module (e.g. PICO inverters).
+
+## Supported Hardware
+
+Is currently working with the following KOSTA inverter modules:
+
+  * KOSTAL PIKO 7.0
+
+# Configuration
+
+## plugin.conf
+
+Please provide a plugin.conf snippet for your plugin with ever option your plugin supports. Optional attributes should be commented out.
+
+<pre>
+[KOSTAL]
+   class_name = Kostal
+   class_path = plugins.kostal
+   ip = 10.10.10.10
+#   user = pvserver
+#   passwd = pvwr
+#   cycle = 300
+</pre>
+
+This plugin retrieves data from a KOSTAL inverter module of a solar energy
+plant.
+
+The data retrieval is done by establishing a network connection to the 
+inverter module and retrieving the status via a HTTP request.
+
+You need to configure the host (or IP) address of the inverter module. Also
+the user and password attributes (user, passwd) can be overwritten, but
+defaults to the standard credentials.
+
+The cycle parameter defines the update interval and defaults to 300 seconds.
+
+## items.conf
+
+### kostal
+
+This attribute references the information to retrieve by the plugin. The
+following list of information can be specified:
+
+  * power_current: The current power of the solar installation
+  * power_total: The total amount of generated energy
+  * power_day: The amount of generated energy for the current day
+  * status: The textual status of the module (off, feeding, ...)
+  * string1_volt ... string3_volt: The current voltage of string 1, 2, 3
+  * string1_ampere ... string3_ampere: The current ampere of string 1, 2, 3
+  * l1_volt ... l3_volt: The current voltage of L 1, 2, 3
+  * l1_watt ... l3_watt: The current watt of L 1, 2, 3
+
+### Example
+
+Please provide an item configuration with every attribute and usefull settings.
+
+<pre>
+# items/my.conf
+
+[solar]
+    [[current]]
+        type = num
+        kostal = 1
+</pre>
+
+## logic.conf
+If your plugin support item triggers as well, please describe the attributes like the item attributes.
+
+
+# Methodes
+If your plugin provides methods for logics. List and describe them here...
+
+## method1(param1, param2)
+This method enables the logic to send param1 and param2 to the device. You could call it with `sh.my.method1('String', 2)`.
+
+## method2()
+This method does nothing.

--- a/plugins/kostal/__init__.py
+++ b/plugins/kostal/__init__.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# vim: set encoding=utf-8 tabstop=4 softtabstop=4 shiftwidth=4 expandtab
+#########################################################################
+# Copyright 2013 KNX-User-Forum e.V.            http://knx-user-forum.de/
+#########################################################################
+#  This file is part of SmartHome.py.   http://smarthome.sourceforge.net/
+#
+#  SmartHome.py is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SmartHome.py is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SmartHome.py. If not, see <http://www.gnu.org/licenses/>.
+#########################################################################
+
+import logging
+import time
+import re
+
+logger = logging.getLogger('')
+
+class Kostal():
+    _key2td = {
+      'power_current'    : 9,
+      'power_total'      : 12,
+      'power_day'        : 21,
+      'status'           : 27,
+      'string1_volt'     : 45,
+      'string2_volt'     : 69,
+      'string3_volt'     : 93,
+      'string1_ampere'   : 54,
+      'string2_ampere'   : 78,
+      'string3_ampere'   : 102,
+      'l1_volt'          : 48,
+      'l2_volt'          : 72,
+      'l3_volt'          : 96,
+      'l1_watt'          : 57,
+      'l2_watt'          : 81,
+      'l3_watt'          : 105
+    }
+
+    def __init__(self, smarthome, ip, user = "pvserver", passwd = "pvwr", cycle = 300):
+        self._sh = smarthome
+        self.ip = ip
+        self.user = user
+        self.passwd = passwd
+        self.cycle = int(cycle)
+        self._items = []
+        self._values = {}
+
+    def run(self):
+        self.alive = True
+        self._sh.scheduler.add('Kostal', self._refresh, cycle=self.cycle)
+
+    def stop(self):
+        self.alive = False
+
+    def parse_item(self, item):
+        if 'kostal' in item.conf:
+            kostal_key = item.conf['kostal']
+            if kostal_key in self._key2td:
+                self._items.append([item, kostal_key])
+                return self.update_item
+            else:
+                logger.warn('invalid key {0} configured', kostal_key);
+        return None
+
+    def parse_logic(self, logic):
+        pass
+
+    def update_item(self, item, caller=None, source=None, dest=None):
+        if caller != 'Kostal':
+            pass
+
+    def _refresh(self):
+        start = time.time()
+        try:
+          data = self._sh.tools.fetch_url('http://' + self.ip + '/', self.user, self.passwd, timeout=2).decode()
+          data = re.sub(r'<([a-zA-Z0-9]+)(\s+[^>]*)>', r'<\1>', data)  # remove all attributes for easy findall()
+          table = re.findall(r'<td>([^<>]*)</td>', data, re.M|re.I|re.S)  # search all TD elements
+          for kostal_key in self._key2td:
+              value = table[self._key2td[kostal_key]].strip()
+              logger.debug('set {0} = {1}'.format(kostal_key, value))
+              self._values[kostal_key] = value
+          for item_cfg in self._items:
+              item_cfg[0](self._values[item_cfg[1]], 'Kostal');
+        except Exception as e:
+            logger.error('could not retrieve data from {0}: {1}'.format(self.ip, e))
+            return
+
+        cycletime = time.time() - start
+        logger.debug("cycle takes {0} seconds".format(cycletime))
+


### PR DESCRIPTION
This plugins retrieves data from the KOSTAL inverter modules (currently tested with PICO 7.0). It retrieves the data using the web-interface of the inverter module and extracting the information from there.

Currently only the values on the main page of the web-interface are supported. The values from the info page can be added if required.
