### PR TITLE
Automatically adjust wait timeout in fader

### DIFF
--- a/lib/item.py
+++ b/lib/item.py
@@ -132,9 +132,9 @@ def _fadejob(item, dest, step, delta):
             item._lock.acquire()
             item._lock.wait(timeout)
             item._lock.release()
-            cnt += 1
             duration = time.time() - start - cnt * delta
             timeout =  delta * (delta / duration)
+            cnt += 1
 
     else:
         while (item._value - step) > dest and item._fading:
@@ -142,9 +142,9 @@ def _fadejob(item, dest, step, delta):
             item._lock.acquire()
             item._lock.wait(timeout)
             item._lock.release()
-            cnt += 1
             duration = time.time() - start - cnt * delta
             timeout =  delta * (delta / duration)
+            cnt += 1
     if item._fading:
         item._fading = False
         item(dest, 'Fader')


### PR DESCRIPTION
I was trying to use the `item.fade()` function with a short interval (something like ~0.02) and noticed that the execution of the complete fade process took longer than expected by the amount of steps required to fade to the target color.

Example: Current value is 100, target value is 200 and should be incremented by 1 each 0.02 seconds. The total execution time should be 100 \* 0.02 = 2 seconds. But since the execution time of one single step is not taken into account, the total execution time was a little bit larger (guessed ~2.2 seconds), which makes problems when you want to synchronize things.

The following patch adjusts the timeout dynamically by checking the execution time of each step with the time expected. If it's larger than expected than the timeout is decreased, if it's shorter the timeout will be increased. This way the total execution will nearly be the expected execution time.

One thing came into my mind: what, if the fade execution time for each step is longer than the given delta? E.g. the processing of one fade step will take 0.01 seconds, but the delta is 0.005. Maybe this border case should be checked. But while testing a little bit around I never came into this situation. A possible solution would also be to check if the specified delta is not shorter that the possible one (maybe 0.01 or 0.02 - don't know how fast a machine can be) - but this will only be a guessed limit.
