### PR TITLE
CLI Plugin: List items matching a pattern

### DIFF
--- a/plugins/cli/__init__.py
+++ b/plugins/cli/__init__.py
@@ -109,11 +109,15 @@ class CLIHandler(lib.connection.Stream):
         if not value:
             self.push("You have to specify an item value. Syntax: up item = value\n")
             return
-        item = self.sh.return_item(path)
-        if not hasattr(item, '_type'):
-            self.push("Could not find item with a valid type specified: '{0}'\n".format(path))
-            return
-        item(value, 'CLI', self.source)
+        items = self.sh.match_items(path)
+        if len(items):
+            for item in items:
+                if not hasattr(item, '_type'):
+                    self.push("Item has no valid type specified: '{0}'\n".format(item.id()))
+                    return
+                item(value, 'CLI', self.source)
+        else:
+            self.push("Could not find any item with given pattern: '{0}'\n".format(path))
 
     def tr(self, logic):
         if not self.updates_allowed:

--- a/plugins/cli/__init__.py
+++ b/plugins/cli/__init__.py
@@ -75,19 +75,27 @@ class CLIHandler(lib.connection.Stream):
     def cl(self):
         self.sh.log.clean(self.sh.now())
 
-    def ls(self, path):
+    def ls(self, path, match=True):
         if not path:
             for item in self.sh:
                 self.push("{0}\n".format(item.id()))
         else:
-            item = self.sh.return_item(path)
-            if hasattr(item, 'id'):
-                if item._type:
-                    self.push("{0} = {1}\n".format(item.id(), item()))
-                else:
-                    self.push("{}\n".format(item.id()))
-                for child in item:
-                    self.ls(child.id())
+            if match:
+               items = self.sh.match_items(path)
+               childs = False
+            else:
+               items = [self.sh.return_item(path)]
+               childs = True
+            if len(items):
+                for item in items:
+                    if hasattr(item, 'id'):
+                        if item._type:
+                            self.push("{0} = {1}\n".format(item.id(), item()))
+                        else:
+                            self.push("{}\n".format(item.id()))
+                        if childs:
+                            for child in item:
+                                self.ls(child.id(), False)
             else:
                 self.push("Could not find path: {}\n".format(path))
 

--- a/plugins/cli/__init__.py
+++ b/plugins/cli/__init__.py
@@ -45,7 +45,7 @@ class CLIHandler(lib.connection.Stream):
         cmd = data.decode().strip()
         if cmd.startswith('ls'):
             self.push("Items:\n======\n")
-            self.ls(cmd.lstrip('ls').strip())
+            self.ls(cmd.lstrip('ls').strip(), '*' in cmd or ':' in cmd)
         elif cmd == 'la':
             self.la()
         elif cmd == 'lo':


### PR DESCRIPTION
Just an idea: I have a lot of items and the `la` command output is really large and i need to search for the items I currently want to see, which is not handy.

I implemented a item matching mechanism using the `sh.match_item()` function instead of `sh.return_item()` for:
- `ls` - will list all matching items, e.g. `ls groundfloor.*.light`
- `update`, `up` - will update all matching items to value, e.g. `up groundfloor.*.light = True`

Maybe we should use a new keyword for the update command, since this actually change values and it could happen that someone change a lot of values accidentally by typing a `*` somewhere in the path.

Since every time the match_item() function is used, this patch will slightly slow down the mentioned commands. I did not a benchmark on this, since the CLI interface is mainly used for developers, debugging or testing purpose.

The documentation update is not included in this patch - I can do this if we want to support this feature.
