### PR TITLE
wetter.com plugin: check if expected nodes exist in result XML

### DIFF
--- a/plugins/wettercom/__init__.py
+++ b/plugins/wettercom/__init__.py
@@ -85,14 +85,18 @@ class wettercom():
                     hour, minute = time.attrib['value'].split(':')
                     d = datetime.datetime(int(year), int(month), int(day),
                                           int(hour))
-                    retval[d] = [time.find('tn').text,
-                                 time.find('tx').text,
-                                 time.find('w_txt').text,
-                                 time.find('pc').text,
-                                 time.find('ws').text,
-                                 time.find('wd').text,
-                                 time.find('wd_txt').text,
-                                 time.find('w').text]
+                    items = [time.find('tn'),
+                             time.find('tx'),
+                             time.find('w_txt'),
+                             time.find('pc'),
+                             time.find('ws'),
+                             time.find('wd'),
+                             time.find('wd_txt'),
+                             time.find('w')]
+
+                    retval[d] = []
+                    for item in items:
+                      retval[d].append(None if item is None else item.text)
 
             return retval
 


### PR DESCRIPTION
I tried to use the `wettercom` plugin and it did not work properly since some nodes do not exist in the XML response (for example in my case it was `pc`, `ws`, `wd` and `wd_txt`).

This patch changes the plugin to check for the existence of the requested node before accessing the nodes' content. The value `None` will be returned in case the node does not exist.

Btw. I can't find any documentation describing the XML structure. It could be possible, that some more parameter needs to be transmitted to the service to retrieve the missing data but the API is not well-documented and I can't find something about it.

Further, it also offers a JSON result instead of XML. Handling JSON instead of XML could be a little bit more easy and requires less resources (guess).
