### PR TITLE
CLI plugin: sort logic items

### DIFF
--- a/plugins/cli/__init__.py
+++ b/plugins/cli/__init__.py
@@ -147,7 +147,7 @@ class CLIHandler(lib.connection.Stream):
 
     def lo(self):
         self.push("Logics:\n")
-        for logic in self.sh.return_logics():
+        for logic in sorted(self.sh.return_logics()):
             nt = self.sh.scheduler.return_next(logic)
             if nt is not None:
                 self.push("{0} (scheduled for {1})\n".format(logic, nt.strftime('%Y-%m-%d %H:%M:%S%z')))


### PR DESCRIPTION
Just a small patch which makes the list of logics dumped out by the `ll` or `lo` command ordered by thier string representation.

Having a large list of logics configured makes it hard to find the right one to force a reload or do a trigger in CLI. Now it's easy to find it and copy&paste it.

I was also thinking about to only list logics matching a given pattern. Could be implemented in a method called `sh.scheduler.match_logics()` - like the `match_items()` method.
