### PR TITLE
Redeveloped plugin with support for ComfoAir 350 and 500

### DIFF
--- a/plugins/comfoair/__init__.py
+++ b/plugins/comfoair/__init__.py
@@ -241,7 +241,7 @@ class ComfoAir():
                 else:
                     tdelay = 5 # default delay
                     if 'comfoair_trigger_afterwrite' in item.conf:
-                        tdelay = item.conf['comfoair_trigger_afterwrite']
+                        tdelay = float(item.conf['comfoair_trigger_afterwrite'])
                     if type(trigger) != list:
                         trigger = [trigger] 
                     for triggername in trigger:


### PR DESCRIPTION
Completely redesigned plugin version using a "synchronous" approach: Send read command, wait for response.
Flexible configuration of new commands to easily support new commandsets for other KWL systems.
The configuration of which parameters of the KWL will be fetched is not hard-coded anymore but is configured by the SmartHome.py items.
Supports direct serial connection and TCP connection (for TCP-to-serial converter).
