### PR TITLE
Redeveloped plugin with support for ComfoAir 350 and 500

### DIFF
--- a/plugins/comfoair/commands.py
+++ b/plugins/comfoair/commands.py
@@ -1,44 +1,93 @@
 #!/usr/bin/env python
-# vim: set encoding=utf-8 tabstop=4 softtabstop=4 shiftwidth=4 expandtab
 #########################################################################
-# Copyright 2012-2013 KNX-User-Forum e.V.       http://knx-user-forum.de/
+# Copyright 2013 Stefan Kals
 #########################################################################
-#  This file is part of SmartHome.py.
+#  ComfoAir-Plugin for SmartHome.py.  http://mknx.github.com/smarthome/
 #
-#  SmartHome.py is free software: you can redistribute it and/or modify
+#  This plugin is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
 #
-#  SmartHome.py is distributed in the hope that it will be useful,
+#  This plugin is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with SmartHome.py.  If not, see <http://www.gnu.org/licenses/>.
+#  along with this plugin. If not, see <http://www.gnu.org/licenses/>.
 #########################################################################
-	
-commands = {
-    'KEY_Komforttemp': '00D100',
-    'KEY_Aussentemp': '00D100',
-    'KEY_Zulufttemp': '00D100',
-    'KEY_Ablufttemp': '00D100',
-    'KEY_Fortlufttemp': '00D100',
-    'KEY_EWTtemp': '00D100',
-    'KEY_Vent_Zuluft_Status':'000B00',
-    'KEY_Vent_Abluft_Status':'000B00',
-    'KEY_Vent_Abluft_Umdrehungen':'000B00',
-    'KEY_Vent_Zuluft_Umdrehungen':'000B00',
-    'KEY_BypassZustand':'000D00',
-    'KEY_StundenFilter':'00DD00',
-    'KEY_Badschalter':'000300',
-    'KEY_AktuelleStufe':'00CD00',
-    'KEY_Komforttemperatur': '00D301',
-    'KEY_StufeAbwesend':'00990101',
-    'KEY_StufeEins':'00990102',
-    'KEY_StufeZwei':'00990103',
-    'KEY_StufeDrei':'00990104',
-    'KEY_ResetFilter':'00DB0400000001',
-    'KEY_ResetError':'00DB0401000000',
+
+controlset = {
+    'comfoair350': {
+        'PacketStart': 0x07F0,
+        'PacketEnd': 0x070F,
+        'Acknowledge': 0x07F3,
+        'SpecialCharacter': 0x07,
+        'ResponseCommandIncrement': 1
+    },
+    'comfoair500': {
+        'PacketStart': 0x07F0,
+        'PacketEnd': 0x070F,
+        'Acknowledge': 0x07F3,
+        'SpecialCharacter': 0x07,
+        'ResponseCommandIncrement': -1
+    }
+}
+    
+# Mandatory command properties: Command, Type, ValueBytes
+# Optional command properties: ResponsePosition (only for Type = Read), ValueTransform
+# Remarks:
+# Command must contain the command code (2 bytes) and the data length (1 byte) and can be optionally followed by data bytes.
+# If ValueBytes is greater than 0, the value of the assigned item is taken, formatted to the number of bytes and added to the telegram.
+# The data length byte must already have the correct amount of data bytes (sum of data bytes provided by 'Command' and dynamic data bytes (of 'ValueBytes' length)).
+# Read-Commands MUST always have a length of 3 bytes and no data (third command byte = 00)
+commandset = {
+    'comfoair350': {
+        'ReadComfortTemperature':       { 'Command': 0x00D100, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 1, 'ValueBytes': 1, 'ValueTransform': 'Temperature' },
+        'ReadFreshAirTemperature':      { 'Command': 0x00D100, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 2, 'ValueBytes': 1, 'ValueTransform': 'Temperature' }, # Frischluft, außen
+        'ReadSupplyAirTemperature':     { 'Command': 0x00D100, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 3, 'ValueBytes': 1, 'ValueTransform': 'Temperature' }, # Zuluft, innen
+        'ReadExtractAirTemperature':    { 'Command': 0x00D100, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 4, 'ValueBytes': 1, 'ValueTransform': 'Temperature' }, # Abluft, innen
+        'ReadExhaustAirTemperature':    { 'Command': 0x00D100, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 5, 'ValueBytes': 1, 'ValueTransform': 'Temperature' }, # Fortluft, außen
+        'ReadGroundHeatTemperature':    { 'Command': 0x00D100, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 7, 'ValueBytes': 1, 'ValueTransform': 'Temperature' }, # Erdwärmetauscher
+        'ReadPreHeatingTemperature':    { 'Command': 0x00D100, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 8, 'ValueBytes': 1, 'ValueTransform': 'Temperature' }, # Vorheizung
+        'ReadSupplyAirPercentage':      { 'Command': 0x000B00, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 1, 'ValueBytes': 1 },
+        'ReadExtractAirPercentage':     { 'Command': 0x000B00, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 2, 'ValueBytes': 1 },
+        'ReadSupplyAirRPM':             { 'Command': 0x000B00, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 3, 'ValueBytes': 2, 'ValueTransform': 'RPM' },
+        'ReadExtractAirRPM':            { 'Command': 0x000B00, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 5, 'ValueBytes': 2, 'ValueTransform': 'RPM' },
+        'ReadBypassPercentage':         { 'Command': 0x000D00, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 1, 'ValueBytes': 1 },
+        'ReadPreHeatingStatus':         { 'Command': 0x000D00, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 2, 'ValueBytes': 1 },
+        'ReadOperatingHoursAway':       { 'Command': 0x00DD00, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 1, 'ValueBytes': 3 },
+        'ReadOperatingHoursLow':        { 'Command': 0x00DD00, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 4, 'ValueBytes': 3 },
+        'ReadOperatingHoursMedium':     { 'Command': 0x00DD00, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 7, 'ValueBytes': 3 },
+        'ReadOperatingHoursAntiFreeze': { 'Command': 0x00DD00, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 10, 'ValueBytes': 2 },
+        'ReadOperatingHoursPreHeating': { 'Command': 0x00DD00, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 12, 'ValueBytes': 2 },
+        'ReadOperatingHoursBypass':     { 'Command': 0x00DD00, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 14, 'ValueBytes': 2 },
+        'ReadOperatingHoursFilter':     { 'Command': 0x00DD00, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 16, 'ValueBytes': 2 },
+        'ReadOperatingHoursHigh':       { 'Command': 0x00DD00, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 18, 'ValueBytes': 3 },
+        'ReadCurrentVentilationLevel':  { 'Command': 0x00CD00, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 9, 'ValueBytes': 1 },
+        'WriteComfortTemperature':      { 'Command': 0x00D301, 'CommandBytes': 3, 'Type': 'Write', 'ValueBytes': 1, 'ValueTransform': 'Temperature' },
+        'WriteVentilationLevel':        { 'Command': 0x009901, 'CommandBytes': 3, 'Type': 'Write', 'ValueBytes': 1 },
+        'WriteVentilationLevelAway':    { 'Command': 0x00990101, 'CommandBytes': 4, 'Type': 'Write', 'ValueBytes': 0 },
+        'WriteVentilationLevelLow':     { 'Command': 0x00990102, 'CommandBytes': 4, 'Type': 'Write', 'ValueBytes': 0 },
+        'WriteVentilationLevelMedium':  { 'Command': 0x00990103, 'CommandBytes': 4, 'Type': 'Write', 'ValueBytes': 0 },
+        'WriteVentilationLevelHigh':    { 'Command': 0x00990104, 'CommandBytes': 4, 'Type': 'Write', 'ValueBytes': 0 },
+        'WriteFilterReset':             { 'Command': 0x00DB0400000001, 'CommandBytes': 7, 'Type': 'Write', 'ValueBytes': 0 },
+        'WriteErrorReset':              { 'Command': 0x00DB0401000000, 'CommandBytes': 7, 'Type': 'Write', 'ValueBytes': 0 }
+    },
+    'comfoair500': {
+        'ReadComfortTemperature':       { 'Command': 0x008B00, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 2, 'ValueBytes': 1, 'ValueTransform': 'Temperature' },
+        'ReadFreshAirTemperature':      { 'Command': 0x008500, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 4, 'ValueBytes': 1, 'ValueTransform': 'Temperature' }, # Frischluft, außen
+        'ReadSupplyAirTemperature':     { 'Command': 0x008500, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 7, 'ValueBytes': 1, 'ValueTransform': 'Temperature' }, # Zuluft, innen
+        'ReadExtractAirTemperature':    { 'Command': 0x008500, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 5, 'ValueBytes': 1, 'ValueTransform': 'Temperature' }, # Abluft, innen
+        'ReadExhaustAirTemperature':    { 'Command': 0x008500, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 6, 'ValueBytes': 1, 'ValueTransform': 'Temperature' }, # Fortluft, außen
+        'ReadSupplyAirPercentage':      { 'Command': 0x008700, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 1, 'ValueBytes': 1 },
+        'ReadExtractAirPercentage':     { 'Command': 0x008700, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 2, 'ValueBytes': 1 },
+        'ReadSupplyAirRPM':             { 'Command': 0x008700, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 3, 'ValueBytes': 1 },
+        'ReadExtractAirRPM':            { 'Command': 0x008700, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 4, 'ValueBytes': 1 },
+        'ReadBypassPercentage':         { 'Command': 0x008500, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 1, 'ValueBytes': 1 },
+        'ReadEnthalpyPercentage':       { 'Command': 0x00C100, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 1, 'ValueBytes': 1 },
+        'ReadEnthalpyTemperature':      { 'Command': 0x00C100, 'CommandBytes': 3, 'Type': 'Read', 'ResponsePosition': 2, 'ValueBytes': 1, 'ValueTransform': 'Temperature' },
+        'WriteVentilationLevel':        { 'Command': 0x00A001, 'CommandBytes': 3, 'Type': 'Write', 'ValueBytes': 1 }
+    }
 }


### PR DESCRIPTION
Completely redesigned plugin version using a "synchronous" approach: Send read command, wait for response.
Flexible configuration of new commands to easily support new commandsets for other KWL systems.
The configuration of which parameters of the KWL will be fetched is not hard-coded anymore but is configured by the SmartHome.py items.
Supports direct serial connection and TCP connection (for TCP-to-serial converter).
