### PR TITLE
New Plugin DataLog: Provide easy logging mechanism for items

### DIFF
--- a/plugins/datalog/README.md
+++ b/plugins/datalog/README.md
@@ -1,0 +1,125 @@
+# KOSTAL
+
+# Requirements
+
+Plugin to dump the item data into files on the file system. It can be used
+to configure different logs and log patterns and assign them to the
+items. These items will be logged to the files.
+
+## Supported Hardware
+
+No special hardware required.
+
+# Configuration
+
+## plugin.conf
+
+The plugin can be configured using the following settings:
+
+<pre>
+[datalog]
+   class_name = DataLog
+   class_path = plugins.datalog
+#   path = var/log/data
+#   filepatterns = default:{log}-{year}-{month}-{day}.csv | yearly:{log}-{year}.csv
+#   logpatterns = csv:{time}|{item}|{value}\n
+#   cycle = 300
+</pre>
+
+This will setup the logs `default` and `yearly`, which is using the configured
+patter to build the target file name (key-value pairs). The `default` log is
+configured automatically if you do not specify any file patterns.
+
+Additionally the patterns to use to log the data into the files is configured
+also configured there. The key-value pairs are specifying the file extension
+and the log pattern to use. In this example all log files having the extension
+`.csv` will be logged using the configured pattern. This is also the default
+if you do not specify any log patterns. in the configuration.
+
+Both settings can make use of some placeholders (see below).
+
+The path paramter can be used to log into a different path intead of the default
+path and the cycle parameter defines the interval to use to dump the data
+into the log files, which defaults to 300 seconds.
+
+Placeholders which can be used in the `logpatterns` option:
+
+   * `time` - the string representation of the time
+   * `stamp` - the unix timestamp of the time
+   * `item` - the id of the item
+   * `value` - the value of items
+
+## items.conf
+
+### path
+
+Specifies the path to log into. The default value is `var/log/data` which can
+be changed by using this option. All log files will be logged into this directory.
+It's not possible to configure different log paths for different log files.
+
+### filepatterns
+
+This specifies a list of file patterns, which is used to build the target files
+to log data into. It's using a key-value pair syntax, which means you can
+configure multiple file patterns or log files.
+
+Placeholders which can be used in the `filepatterns` option:
+
+   * `log` - specifies the type of log (e.g. "default" in the example above)
+   * `year` - the current year
+   * `month` - the current month
+   * `day` - the current day
+
+### logpatterns
+
+The log pattners setting configured the format in which the data will be
+logged into the log files. It's using a key-value pair syntax, which means
+you can configure multiple log patterns.
+
+A log pattern is used for logging when a file pattern is configured, where
+the extension (part behind the last `.`) matches the key.
+
+Example:
+<pre>
+[datalog]
+   class_name = DataLog
+   class_path = plugins.datalog
+   filepatterns = default:{log}-{year}-{month}-{day}.csv | custom:{log}-{year}-{month}-{day}.txt
+   logpatterns = csv:{time}|{item}|{value}\n
+</pre>
+
+In this example the `default` log file will use the configured log pattern. The
+`custom` log file is completely ignored, since no pattern is configured.
+
+### Example
+
+Example configuration using the plugin configuration on top of the page.
+
+<pre>
+# items/my.conf
+[some]
+    [[item1]]
+        type = str
+        datalog = default
+    [[item2]]
+        type = num
+        datalog = default | custom
+    [[item3]]
+        type = num
+        datalog = custom
+</pre>
+
+This will log the items
+
+   * `some.item1` to the `default` log
+   * `some.item2` to the `default` and `custom` log 
+   * `some.item3` to the `custom` log
+
+## logic.conf
+
+No logic related stuff implemented.
+
+# Methods
+
+No methods provided currently.
+

--- a/plugins/datalog/README.md
+++ b/plugins/datalog/README.md
@@ -22,7 +22,7 @@ The plugin can be configured using the following settings:
    class_path = plugins.datalog
 #   path = var/log/data
 #   filepatterns = default:{log}-{year}-{month}-{day}.csv | yearly:{log}-{year}.csv
-#   logpatterns = csv:{time}|{item}|{value}\n
+#   logpatterns = csv:{time};{item};{value}\n
 #   cycle = 300
 </pre>
 
@@ -85,7 +85,7 @@ Example:
    class_name = DataLog
    class_path = plugins.datalog
    filepatterns = default:{log}-{year}-{month}-{day}.csv | custom:{log}-{year}-{month}-{day}.txt
-   logpatterns = csv:{time}|{item}|{value}\n
+   logpatterns = csv:{time};{item};{value}\n
 </pre>
 
 In this example the `default` log file will use the configured log pattern. The

--- a/plugins/datalog/README.md
+++ b/plugins/datalog/README.md
@@ -1,4 +1,4 @@
-# KOSTAL
+# DataLog
 
 # Requirements
 

--- a/plugins/datalog/__init__.py
+++ b/plugins/datalog/__init__.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# vim: set encoding=utf-8 tabstop=4 softtabstop=4 shiftwidth=4 expandtab
+#
+# Copyright 2013 KNX-User-Forum e.V.            http://knx-user-forum.de/
+#
+#  This file is part of SmartHome.py.    http://mknx.github.io/smarthome/
+#
+#  SmartHome.py is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SmartHome.py is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SmartHome.py. If not, see <http://www.gnu.org/licenses/>.
+#
+
+import logging
+import time
+import threading
+
+logger = logging.getLogger('')
+
+
+class DataLog():
+    filepatterns = {}
+    logpatterns = {}
+    cycle = 0
+    _items = {}
+    _buffer = {}
+    _buffer_lock = None
+
+    def __init__(self, smarthome, path="var/log/data", filepatterns={ "default" : "{log}-{year}-{month}-{day}.csv" }, logpatterns={ "csv" : "{time}|{item}|{value}\n" }, cycle=10):
+        self._sh = smarthome
+        self.path = path
+
+        if type(filepatterns) is list:
+            for pattern in filepatterns:
+                key, value = pattern.split(':')
+                self.filepatterns[key] = value
+        else:
+            self.filepatterns = filepatterns
+
+        if type(logpatterns) is list:
+            newlogpatterns = {}
+            for pattern in logpatterns:
+                key, value = pattern.split(':')
+                newlogpatterns[key] = value
+            logpatterns = newlogpatterns
+
+        for log in self.filepatterns:
+            ext = self.filepatterns[log].split('.')[-1]
+            if ext in logpatterns:
+                self.logpatterns[log] = logpatterns[ext]
+
+        self.cycle = int(cycle)
+        self._items = {}
+        self._buffer = {}
+        self._buffer_lock = threading.Lock()
+        
+        logger.info('DataLog: Initialized, logging to "{}"'.format(self.path))
+        for log in self.filepatterns:
+            logger.info('DataLog: Registered log "{}", file="{}", format="{}"'.format(log, self.filepatterns[log], self.logpatterns[log]))
+
+    def run(self):
+        self.alive = True
+        self._sh.scheduler.add('DataLog', self._dump, cycle=self.cycle)
+
+    def stop(self):
+        self.alive = False
+        self._dump()
+
+    def parse_item(self, item):
+        if 'datalog' in item.conf:
+            logs = item.conf['datalog']
+
+            if type(logs) is str:
+               logs = [logs]
+
+            for log in logs:
+                if log not in self.filepatterns:
+                    logger.warning("DataLog: Unknown log {} for item {}".format(log, item.id()))
+                    return None
+
+                if log not in self._buffer:
+                    self._buffer[log] = []
+
+                if item.id() not in self._items:
+                    self._items[item.id()] = []
+                elif log not in self._items[item.id()]:
+                    return self.update_item
+
+                self._items[item.id()].append(log)
+
+                return self.update_item
+        return None
+
+    def parse_logic(self, logic):
+        pass
+
+    def update_item(self, item, caller=None, source=None, dest=None):
+        if caller != 'DataLog':
+            pass
+
+        if item.id() in self._items:
+            for log in self._items[item.id()]:
+                self._buffer[log].append({ 'time' : self._sh.now(), 'item' : item.id(), 'value' : item() })
+
+    def _dump(self):
+        data = {}
+        now = self._sh.now()
+        handles = {}
+
+        for log in self._buffer:
+            self._buffer_lock.acquire()
+            logger.debug('DataLog: Dumping log "{}" with {} entries ...'.format(log, len(self._buffer[log])))
+            entries = self._buffer[log]
+            self._buffer[log] = []
+            self._buffer_lock.release()
+
+            if len(entries):
+                logpattern = self.logpatterns[log]
+
+                try:
+                    for entry in entries:
+                        filename = self.filepatterns[log].format(**{ 'log' : log, 'year' : entry['time'].year, 'month' : entry['time'].month, 'day' : entry['time'].day })
+
+                        if filename not in handles:
+                            handles[filename] = open(self.path + '/' + filename, 'a')
+
+                        data = entry
+                        data['stamp'] = data['time'].time();
+                        handles[filename].write(logpattern.format(**data))
+
+                except Exception as e:
+                    logger.error('DataLog: Error while writing to {}: {}'.format(filename, e))
+
+        for filename in handles:
+            handles[filename].close()
+
+        logger.debug('DataLog: Dump done!')
+

--- a/var/log/data/.gitignore
+++ b/var/log/data/.gitignore
@@ -1,5 +1,4 @@
 # ignore everything
 *
-# except .gitignore files
+# except .gitignore
 !.gitignore
-!data/


### PR DESCRIPTION
Usually I use a SQLite database to store all the values and use them to show up some charts in my visualization. The problem with this is, that the data is packed at a certain interval. This will aggregate the information to minimize the database size (e.g. houly data is aggregated to daily, daily to weekly, ...).

This plugin will provide functionality to log the item status into log files to have the item status history available - months or years ago.

This could be useful if you want to still have the data available month ago to do a analyzing task or to import them into other database system or data container (e.g. Excel).

I wrote this plugin, since I still want to keep the detailed item data (e.g. from my solar plant) to still be able to do some further analyzing. I feel better when I know the data is somewhere in the logs, instead of thinking about how to use the aggregated values from the SQLite database - which is IMHO only a performance optimized data container to provide information on a fast way (e.g. for the visualization).

Btw. I also found a [conversation](http://knx-user-forum.de/320568-post10.html) about such a feature to be able to keep some values in the SQLite database. Since I don't want to blow up the SQLite database that much with detailed history data, I think such a plugin could be better.
