### PR TITLE
Issue 59: Support crontab ranges 'x-y' and 'x/y'

### DIFF
--- a/lib/scheduler.py
+++ b/lib/scheduler.py
@@ -358,8 +358,8 @@ class Scheduler(threading.Thread):
             if not next_event:
                 next_event = self._parse_month(crontab, offset=1)  # next month
             return next_event
-        except:
-            logger.error("Error parsing crontab: {}".format(crontab))
+        except Exception as e:
+            logger.error('Error parsing crontab "{}": {}'.format(crontab, e))
             return datetime.datetime.now(tzutc()) + dateutil.relativedelta.relativedelta(years=+10)
 
     def _parse_month(self, crontab, offset=0):
@@ -378,7 +378,7 @@ class Scheduler(threading.Thread):
             day_range = day_range + self._range(day, 0o1, mdays)
         else:
             day_range = self._range(day, 0o1, mdays)
-        # combine the differnt ranges
+        # combine the different ranges
         event_range = sorted([str(day) + '-' + str(hour) + '-' + str(minute) for minute in minute_range for hour in hour_range for day in day_range])
         if offset:  # next month
             next_event = event_range[0]
@@ -472,16 +472,36 @@ class Scheduler(threading.Thread):
     def _range(self, entry, low, high):
         result = []
         item_range = []
-        if entry == '*':
-            item_range = list(range(low, high + 1))
-        else:
+
+        # Check for multiple items and process each item recursively
+        if ',' in entry:
             for item in entry.split(','):
-                item = int(item)
-                if item > high:  # entry above range
-                    item = high  # truncate value to highest possible
-                item_range.append(item)
-        for entry in item_range:
-            result.append('{:02d}'.format(entry))
+                result.extend(self._range(item, low, high))
+
+        # Check for intervals, e.g. "*/2", "9-17/2"
+        elif '/' in entry:
+             spec_range, interval = entry.split('/')
+             logger.error('Cron spec interval {} {}'.format(entry, interval))
+             result = self._range(spec_range, low, high)[::int(interval)]
+
+        # Check for numeric ranges, e.g. "9-17"
+        elif '-' in entry:
+             spec_low, spec_high = entry.split('-')
+             result = self._range('*', int(spec_low), int(spec_high))
+
+        # Process single item
+        else:
+            if entry == '*':
+                item_range = list(range(low, high + 1))
+            else:
+                for item in entry.split(','):
+                    item = int(item)
+                    if item > high:  # entry above range
+                        item = high  # truncate value to highest possible
+                    item_range.append(item)
+            for entry in item_range:
+                result.append('{:02d}'.format(entry))
+
         return result
 
     def _day_range(self, days):

--- a/lib/scheduler.py
+++ b/lib/scheduler.py
@@ -494,11 +494,10 @@ class Scheduler(threading.Thread):
             if entry == '*':
                 item_range = list(range(low, high + 1))
             else:
-                for item in entry.split(','):
-                    item = int(item)
-                    if item > high:  # entry above range
-                        item = high  # truncate value to highest possible
-                    item_range.append(item)
+                item = int(entry)
+                if item > high:  # entry above range
+                    item = high  # truncate value to highest possible
+                item_range.append(item)
             for entry in item_range:
                 result.append('{:02d}'.format(entry))
 


### PR DESCRIPTION
I started to refactor the `scheduler._range()` function a little bit and implemented support for `x/y` and `x-y` as requested in issue #59. The function was changed to resolve the `crontab` elements from complex to simple elements.

The following complex elements are supported now in `crontab` setting:
- list, e.g. `1,2,3,4,8-10`
- intervals, e.g. `*/2`
- ranges, e.g. `0-8`

Since the resolving is implemented in a recusive way, it's also possible to combine all of them. E.g. you can use `1,2,3,4,8-10` or `1-4,5-23/2` or something similar. The first one will include the hours between 1-4 and 8-10, the second one will include the hours between 1-4 and each even hour between 5 and 23.
