### PR TITLE
Fix comfoair empty chunks

### DIFF
--- a/plugins/comfoair/__init__.py
+++ b/plugins/comfoair/__init__.py
@@ -327,7 +327,7 @@ class ComfoAir():
                         bytestoreceive = firstpartlen - len(packet)
                         self.log_debug('Trying to receive {} bytes for the first part of the response.'.format(bytestoreceive))
                         chunk = self.read_bytes(bytestoreceive)
-                        self.log_info('Received chunk of response: {}'.format(self.bytes2hexstring(chunk)))
+                        self.log_info('Received {} bytes chunk of response part 1: {}'.format(len(chunk), self.bytes2hexstring(chunk)))
                         
                         # Cut away old ACK (but only if the telegram wasn't started already)
                         if len(packet) == 0:
@@ -354,7 +354,7 @@ class ComfoAir():
                         bytestoreceive = packetlen - len(packet)
                         self.log_debug('Trying to receive {} bytes for the second part of the response.'.format(bytestoreceive))
                         chunk = self.read_bytes(bytestoreceive)
-                        self.log_info('Received chunk of response: {}'.format(self.bytes2hexstring(chunk)))
+                        self.log_info('Received {} bytes chunk of response part 2: {}'.format(len(chunk), self.bytes2hexstring(chunk)))
                         packet.extend(chunk)
                     except socket.timeout:
                         raise Exception("error receiving second part of packet: timeout")

--- a/plugins/comfoair/__init__.py
+++ b/plugins/comfoair/__init__.py
@@ -328,6 +328,8 @@ class ComfoAir():
                         self.log_debug('Trying to receive {} bytes for the first part of the response.'.format(bytestoreceive))
                         chunk = self.read_bytes(bytestoreceive)
                         self.log_info('Received {} bytes chunk of response part 1: {}'.format(len(chunk), self.bytes2hexstring(chunk)))
+                        if len(chunk)  == 0:
+                            raise Exception('Received 0 bytes chunk - ignoring packet!')
                         
                         # Cut away old ACK (but only if the telegram wasn't started already)
                         if len(packet) == 0:
@@ -356,6 +358,8 @@ class ComfoAir():
                         chunk = self.read_bytes(bytestoreceive)
                         self.log_info('Received {} bytes chunk of response part 2: {}'.format(len(chunk), self.bytes2hexstring(chunk)))
                         packet.extend(chunk)
+                        if len(chunk)  == 0:
+                            raise Exception('Received 0 bytes chunk - ignoring packet!')
                     except socket.timeout:
                         raise Exception("error receiving second part of packet: timeout")
                     except Exception as e:


### PR DESCRIPTION
In some (rare) situations it happens that the serial device reports readyness but returns no data. In this case an empty chunk is returned.

Usually this is not a problem, since it only happens in rare situtions (e.g. when the device has an invalid state or data transfer errors happened). But when this happens while the plugin is waiting for a response, it will end up in an endless loop still trying to read the response.

This patch catches the situation when an empty chunk is received and will raise an exception to completely ignore the packetand try to reconnect.

I don't know if this patch is really helpful since this problem should not  happen when everything goes well. But I had problems with my serial device which was causing overload since the plugin created new threads  while old threads are still trying to read data. This patch helped me out there for the time I tried to fix the serial device (was a hardware problem).

On the other handI think the plugin should never create an endless loop and should cover such situations.
