### PR TITLE
Configure dictionaries in config files

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -94,7 +94,12 @@ def parse(filename, config=None):
                 if not set(attr).issubset(valid_set):
                     logger.error("Problem parsing '{}' invalid character in line {}: {}. Valid characters are: {}".format(filename, linenu, attr, valid_chars))
                     continue
-                if '|' in value:
+                if value.strip()[0] == '{' and value.strip()[-1] == '}':
+                    item[attr] = {}
+                    for x in value.strip()[1:-2].split('|'):
+                        keyname, __, keyvalue = x.partition(':')
+                        item[attr][strip_quotes(keyname)] = strip_quotes(keyvalue)
+                elif '|' in value:
                     item[attr] = [strip_quotes(x) for x in value.split('|')]
                 else:
                     item[attr] = strip_quotes(value)


### PR DESCRIPTION
Currently only simple key/values and lists are supported in configuration files like `smarthome.conf` or `plugin.conf`.

This patch makes it possible to configure dictionaly using the following syntax:

```
[section]
  list = value1 | value2 | ...
  dict = { key1 : value2 | key2 : value2 | key3 : value3 | ...}
```

I think some plugins or the core itself can make use of such a configuration style to make the configuration a little bit easier and be more flexible in configuration settings.
