### PR TITLE
New "ld" (log dump) command for CLI

### DIFF
--- a/plugins/cli/README.md
+++ b/plugins/cli/README.md
@@ -26,6 +26,7 @@ Telnet to the configured IP adress and port.
 <code>help</code>list an set of available commands:
 <pre>
 cl: clean (memory) log
+ld: log dump of (memory) logs
 ls: list the first level items
 ls item: list item and every child item (with values)
 la: list all items (with values)

--- a/plugins/cli/__init__.py
+++ b/plugins/cli/__init__.py
@@ -48,6 +48,8 @@ class CLIHandler(lib.connection.Stream):
             self.ls(cmd.lstrip('ls').strip())
         elif cmd == 'la':
             self.la()
+        elif cmd == 'ld':
+            self.ld()
         elif cmd == 'lo':
             self.lo()
         elif cmd == 'll':
@@ -100,6 +102,12 @@ class CLIHandler(lib.connection.Stream):
                 self.push("{0} = {1}\n".format(item.id(), item()))
             else:
                 self.push("{0}\n".format(item.id()))
+
+    def ld(self, name = None):
+        for entry in self.sh.log.last(10):
+            values = [str(value) for value in entry]
+            self.push(str(values))
+            self.push("\n")
 
     def update(self, data):
         if not self.updates_allowed:
@@ -168,6 +176,7 @@ class CLIHandler(lib.connection.Stream):
 
     def usage(self):
         self.push('cl: clean (memory) log\n')
+        self.push('ld: log dump of (memory) log\n')
         self.push('ls: list the first level items\n')
         self.push('ls item: list item and every child item (with values)\n')
         self.push('la: list all items (with values)\n')

--- a/plugins/cli/__init__.py
+++ b/plugins/cli/__init__.py
@@ -60,6 +60,8 @@ class CLIHandler(lib.connection.Stream):
             self.lt()
         elif cmd == 'cl':
             self.cl()
+        elif cmd.startswith('cl '):
+            self.cl(cmd.lstrip('cl ').strip())
         elif cmd.startswith('update ') or cmd.startswith('up '):
             self.update(cmd.lstrip('update').strip())
         elif cmd.startswith('tr'):
@@ -78,8 +80,19 @@ class CLIHandler(lib.connection.Stream):
             return
         self.push("> ")
 
-    def cl(self):
-        self.sh.log.clean(self.sh.now())
+    def cl(self, name = None):
+        if name == None or name == "":
+            log = self.sh.log
+        else:
+            logs = self.sh.return_logs()
+            if name not in logs:
+                self.push("Log '{0}' does not exist\n".format(name))
+                log = None
+            else:
+                log = logs[name]
+
+        if log != None:
+            log.clean(self.sh.now())
 
     def ls(self, path):
         if not path:

--- a/plugins/cli/__init__.py
+++ b/plugins/cli/__init__.py
@@ -50,6 +50,8 @@ class CLIHandler(lib.connection.Stream):
             self.la()
         elif cmd == 'ld':
             self.ld()
+        elif cmd.startswith('ld '):
+            self.ld(cmd.lstrip('ld ').strip())
         elif cmd == 'lo':
             self.lo()
         elif cmd == 'll':
@@ -104,10 +106,22 @@ class CLIHandler(lib.connection.Stream):
                 self.push("{0}\n".format(item.id()))
 
     def ld(self, name = None):
-        for entry in self.sh.log.last(10):
-            values = [str(value) for value in entry]
-            self.push(str(values))
-            self.push("\n")
+        if name == None or name == "":
+            log = self.sh.log
+        else:
+            logs = self.sh.return_logs()
+            if name not in logs:
+                self.push("Log '{0}' does not exist\n".format(name))
+                log = None
+            else:
+                log = logs[name]
+
+        if log != None:
+            self.push("Log dump of '{0}':\n".format(log._name))
+            for entry in log.last(10):
+                values = [str(value) for value in entry]
+                self.push(str(values))
+                self.push("\n")
 
     def update(self, data):
         if not self.updates_allowed:
@@ -176,7 +190,7 @@ class CLIHandler(lib.connection.Stream):
 
     def usage(self):
         self.push('cl: clean (memory) log\n')
-        self.push('ld: log dump of (memory) log\n')
+        self.push('ld: log dump of (memory) logs\n')
         self.push('ls: list the first level items\n')
         self.push('ls item: list item and every child item (with values)\n')
         self.push('la: list all items (with values)\n')


### PR DESCRIPTION
The CLI plugin will get a new command `ld` (log dump) which can be used to dump a log to the console. It will return the items of the SmartHome.py internal log (`env.core.log`, see first example), but can also be used with other log when a name is specified (see second example).

```
> ld
Log dump of 'env.core.log':
['2014-03-03 00:04:21.381223+01:00', 'Connections', 'ERROR', 'TCPDispatcher: problem binding 0.0.0.0:2727 (TCP): [Errno 98] Address already in use']
['2014-03-03 00:04:11.274116+01:00', 'Connections', 'ERROR', 'WebSocket: problem binding 0.0.0.0:2424 (TCP): [Errno 98] Address already in use']
['2014-03-03 00:04:11.263054+01:00', 'Connections', 'ERROR', 'TCPDispatcher: problem binding 0.0.0.0:2727 (TCP): [Errno 98] Address already in use']
['2014-03-03 00:04:01.118701+01:00', 'Connections', 'ERROR', 'WebSocket: problem binding 0.0.0.0:2424 (TCP): [Errno 98] Address already in use']
['2014-03-03 00:04:01.107315+01:00', 'Connections', 'ERROR', 'TCPDispatcher: problem binding 0.0.0.0:2727 (TCP): [Errno 98] Address already in use']
[...]
> ld env.core.log
Log dump of 'env.core.log':
['2014-03-03 00:04:21.381223+01:00', 'Connections', 'ERROR', 'TCPDispatcher: problem binding 0.0.0.0:2727 (TCP): [Errno 98] Address already in use']
['2014-03-03 00:04:11.274116+01:00', 'Connections', 'ERROR', 'WebSocket: problem binding 0.0.0.0:2424 (TCP): [Errno 98] Address already in use']
['2014-03-03 00:04:11.263054+01:00', 'Connections', 'ERROR', 'TCPDispatcher: problem binding 0.0.0.0:2727 (TCP): [Errno 98] Address already in use']
['2014-03-03 00:04:01.118701+01:00', 'Connections', 'ERROR', 'WebSocket: problem binding 0.0.0.0:2424 (TCP): [Errno 98] Address already in use']
['2014-03-03 00:04:01.107315+01:00', 'Connections', 'ERROR', 'TCPDispatcher: problem binding 0.0.0.0:2727 (TCP): [Errno 98] Address already in use']
[...]
> 
```
