### PR TITLE
New Plugin MemLog: Create in-memory logs

### DIFF
--- a/plugins/memlog/README.md
+++ b/plugins/memlog/README.md
@@ -1,0 +1,56 @@
+# MemLog
+
+This plugins can be used to create in-memory logs which can be used by items or other
+plugins.
+
+# Requirements
+
+No special requirements.
+
+# Configuration
+
+## plugin.conf
+
+Use the plugin configuration to configure the in-memory logs.
+
+<pre>
+[memlog]
+   class_name = MemLog
+   class_path = plugins.memlog
+   name = alert
+#   maxlen = 50
+</pre>
+
+This will register a in-memory log with the name "alert". This can be used to attach 
+to items.
+
+## items.conf
+
+The following attributes can be used.
+
+### memlog
+
+Defines the name of in-memory log which should be used to log the item's content to
+the log.
+
+### Example
+
+Simple item logging:
+
+<pre>
+# items/my.conf
+
+[some]
+    [[item]]
+        type = str
+        memlog = alert
+</pre>
+
+## logic.conf
+
+No logic configuration implemented.
+
+# Methodes
+
+No methods implemented.
+

--- a/plugins/memlog/README.md
+++ b/plugins/memlog/README.md
@@ -18,11 +18,38 @@ Use the plugin configuration to configure the in-memory logs.
    class_name = MemLog
    class_path = plugins.memlog
    name = alert
+#   mappings = time | thread | level | message
 #   maxlen = 50
+#   items = first.item.now | second.item.thread.info | third.item.level | fourth.item.msg
 </pre>
 
 This will register a in-memory log with the name "alert". This can be used to attach 
 to items.
+
+### name attribute
+
+This will give the in-memory log a name which can be used when accessing them.
+
+### mappings attribute
+
+This configures the list of values which are logged for each log message. The following
+internal mappings can be used and will be automatically set - if not given explicitely
+when logging data:
+* `time` - the timestamp of log
+* `thread` - the thread logging data
+* `level` - the log level (defaults to INFO)
+
+### maxlen attribute
+
+Defines the maximum amount of log entries in the in-memory log.
+
+### items attribute
+
+Each time an item is updated using the `memlog` configuration setting, a log entry will
+be written using the list of items configured in this attribute as log values.
+
+When this is not configured, the default mapping values will be used the the associated
+item`s value will be logged.
 
 ## items.conf
 
@@ -31,7 +58,7 @@ The following attributes can be used.
 ### memlog
 
 Defines the name of in-memory log which should be used to log the item's content to
-the log.
+the log. Everything is logged with 'INFO' level.
 
 ### Example
 
@@ -52,5 +79,21 @@ No logic configuration implemented.
 
 # Methodes
 
-No methods implemented.
+The `memlog()` method name is the plugin name which is used in the plugin configuration.
+If you use another name, you need to use this name as method name too.
+
+## memlog(entry)
+This log the given list of elements of `entry` parameter. The lsit should have the same amount
+of items you used in the mapping parameter (see also the default for this value).
+
+`sh.memlog((self._sh.now(), threading.current_thread().name, 'INFO', 'Some information'))`
+
+## memlog(msg)
+
+This log the given message in `msg` parameter with the default log level.
+
+## memlog(lvl, msg)
+
+This logs the message in `msg` parameter with the given log level specified in `lvl`
+parameter.
 

--- a/plugins/memlog/__init__.py
+++ b/plugins/memlog/__init__.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# vim: set encoding=utf-8 tabstop=4 softtabstop=4 shiftwidth=4 expandtab
+#########################################################################
+# Copyright 2013 KNX-User-Forum e.V.            http://knx-user-forum.de/
+#########################################################################
+#  This file is part of SmartHome.py.    http://mknx.github.io/smarthome/
+#
+#  SmartHome.py is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SmartHome.py is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SmartHome.py. If not, see <http://www.gnu.org/licenses/>.
+#########################################################################
+
+import logging
+import threading
+import datetime
+import time
+import lib.log
+
+logger = logging.getLogger('')
+
+
+class MemLog():
+    _log = None
+    _items = {}
+
+    def __init__(self, smarthome, name, mapping = ['time', 'thread', 'level', 'message'], items = [], maxlen = 50):
+        self._sh = smarthome
+        self.name = name
+        self._log = lib.log.Log(smarthome, name, mapping, maxlen)
+        self._items = items
+
+    def run(self):
+        self.alive = True
+
+    def stop(self):
+        self.alive = False
+
+    def parse_item(self, item):
+        if 'memlog' in item.conf and item.conf['memlog'] == self.name:
+            return self.update_item
+        else:
+            return None
+
+    def parse_logic(self, logic):
+        pass
+
+    def update_item(self, item, caller=None, source=None, dest=None):
+        if caller != 'MemLog':
+            if item.conf['memlog'] == self.name:
+                if len(self._items) == 0:
+                    log = [self._sh.now(), threading.current_thread().name, 'INFO', item()]
+                else:
+                    log = []
+                    for item in self._items:
+                        log.append(self._sh.return_item(item)())
+                self._log.add(log)
+

--- a/plugins/memlog/__init__.py
+++ b/plugins/memlog/__init__.py
@@ -53,14 +53,41 @@ class MemLog():
     def parse_logic(self, logic):
         pass
 
+    def __call__(self, param1=None, param2=None):
+        logger.debug("{0}".format(param1))
+        self.log(['Hello'], 'INFO')
+        if type(param1) == list and type(param2) == type(None):
+            self.log(param1)
+        elif type(param1) == str and type(param2) == type(None):
+            self.log([param1])
+        elif type(param1) == str and type(param2) == str:
+            self.log([param2], param1)
+
     def update_item(self, item, caller=None, source=None, dest=None):
         if caller != 'MemLog':
             if item.conf['memlog'] == self.name:
                 if len(self._items) == 0:
-                    log = [self._sh.now(), threading.current_thread().name, 'INFO', item()]
+                    logvalues = [item()]
                 else:
-                    log = []
+                    logvalues = []
                     for item in self._items:
-                        log.append(self._sh.return_item(item)())
-                self._log.add(log)
+                        logvalues.append(self._sh.return_item(item)())
+
+                self.log(logvalues, 'INFO')
+
+    def log(self, logvalues, level = 'INFO'):
+        if len(logvalues):
+            log = []
+            for name in self._log.mapping:
+                if name == 'time':
+                    log.append(self._sh.now())
+                elif name == 'thread':
+                    log.append(threading.current_thread().name)
+                elif name == 'level':
+                    log.append(level)
+                else:
+                    log.append(logvalues[0])
+                    logvalues = logvalues[1:]
+
+            self._log.add(log)
 

--- a/plugins/memlog/__init__.py
+++ b/plugins/memlog/__init__.py
@@ -54,8 +54,6 @@ class MemLog():
         pass
 
     def __call__(self, param1=None, param2=None):
-        logger.debug("{0}".format(param1))
-        self.log(['Hello'], 'INFO')
         if type(param1) == list and type(param2) == type(None):
             self.log(param1)
         elif type(param1) == str and type(param2) == type(None):


### PR DESCRIPTION
I was searching for a solution to generate messages which can be shown in the visualization software. My first thought was to have a simple log file which could be read and transferred to the client. But then I saw the `log` command in the `visu` plugin, which is using a in-memory log and I think this could be a good idea to solve this.

I created a new `memlog` plugin which can be used to configure different in-memory logs (see also [this](http://knx-user-forum.de/smartvisu/31449-verwendung-des-status-log-widgets.html) discussion). With this it's now possible to configure several in-memory logs for different purpose.

I was thinking about a in-memory logs for some alerts (I don't need them in a real log or in a history, I just want to show some messages in the visualization), which shows up some still open windows when entering absence status, or which shows up messages when a phone call was while absent, or heating is still turned on when windows are open, or ...

Take a look at the `README.md` file, to see what's possible with this plugin. In short, you can attach them to items to log the string message / item value and you'll be able to use them in the logics.
