### PR TITLE
Update README.md

### DIFF
--- a/plugins/kathrein/README.md
+++ b/plugins/kathrein/README.md
@@ -80,7 +80,7 @@ up
 down
 right
 left
-back
+exit
 standby
 text
 vol+


### PR DESCRIPTION
There is an error in the documentation of ufsControl which names the "Back" key back instead of exit.
