### PR TITLE
Initial commit for elro-plugin. This plugin can be used, to control a rc...

### DIFF
--- a/plugins/elro/README.md
+++ b/plugins/elro/README.md
@@ -1,0 +1,90 @@
+# Elro
+
+# Description
+
+You can use this Plugin to control elro (or elro-based) remote-contro-switches (rc-switches). If the backend-server uses the same command-syntax as the rc_switch_server project, you can even control non-elro rc-switches too! (Or everything other that can be switched on and off)
+
+For rc_switch_server command-syntax look at https://github.com/Brootux/rc_switch_server.py (Server-Clients)
+
+# Requirements
+
+  * Installed and running rc_switch_server (https://github.com/Brootux/rc_switch_server.py)
+
+# Configuration
+## plugin.conf
+
+<pre>
+[elro]
+    class_name = Elro
+    class_path = plugins.elro
+    elro_host = "localhost"
+    elro_port = 6700
+</pre>
+
+Description of the attributes:
+
+* __elro_host__: ip address of the rc_switch_server (mandatory)
+* __elro_port__: port of the rc_switch_server (mandatory)
+
+## items.conf
+
+This plugin has just mandatory item-fields. So you have always use all fields showed in the following example.
+
+### Example
+
+<pre>
+# items/rc_switches.conf
+[RCS]
+    [[A]]
+        type = bool
+        elro_system_code = 0.0.0.0.1
+        elro_unit_code = 1
+        elro_send = value
+        enforce_updates = yes
+        visu_acl = rw
+    [[B]]
+        type = bool
+        elro_system_code = 0.0.0.0.1
+        elro_unit_code = 2
+        elro_send = value
+        enforce_updates = yes
+        visu_acl = rw
+    [[C]]
+        type = bool
+        elro_system_code = 0.0.0.0.1
+        elro_unit_code = 4
+        elro_send = value
+        enforce_updates = yes
+        visu_acl = rw
+    [[D]]
+        type = bool
+        elro_system_code = 0.0.0.0.1
+        elro_unit_code = 8
+        elro_send = value
+        enforce_updates = yes
+        visu_acl = rw
+</pre>
+
+Description of the attributes:
+
+* __elro_system_code__: the code of your home (mandatory)
+* __elro_unit_code__: the code of the unit, you want to switch (mandatory)
+* __elro_send__: use always "value" here (mandatory)
+
+Hints:
+* For __elro_system_code__ you have to set the correct bits of you code (no conversion)
+* For __elro_unit_code__ you have to convert your settings to binary (A = 1, B = 2, C = 4, D = 8, ...)
+* For __elro_send__ always use the transmitting of a value per button (because sometimes the signals dont get transported correctly from remote-transmitter, so you should have the chance to send "on" or "off" more than once)
+
+## SmartVisu
+
+I suggest you to use the following setup per rc-switch:
+
+
+```html
+<span data-role="controlgroup" data-type="horizontal">
+	<h3>TV-Center</h3>
+	{{ basic.button('rcs_tv_on', 'RCS.A', 'On', '', '1', 'midi') }}
+	{{ basic.button('rcs_tv_off', 'RCS.A', 'Off', '', '0', 'midi') }}
+</span>
+```

--- a/plugins/elro/__init__.py
+++ b/plugins/elro/__init__.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# vim: set encoding=utf-8 tabstop=4 softtabstop=4 shiftwidth=4 expandtab
+#
+# Copyright 2013 KNX-User-Forum e.V.            http://knx-user-forum.de/
+#
+#  This file is part of SmartHome.py.    http://mknx.github.io/smarthome/
+#
+#  SmartHome.py is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SmartHome.py is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SmartHome.py. If not, see <http://www.gnu.org/licenses/>.
+#
+
+import logging
+import re
+import socket
+
+logger = logging.getLogger('elro')
+
+
+class Elro():
+
+    def __init__(self, smarthome, elro_host="localhost", elro_port=6700):
+        self._sh = smarthome
+        self._host = elro_host
+        self._port = int(elro_port)
+        logger.info("ELRO WAS CREATED")
+
+    def run(self):
+        self.alive = True
+
+    def stop(self):
+        self.alive = False
+
+    def parse_item(self, item):
+        # Check if there are elro_system_code, elro_unit_code and elro_send fields for a item
+        if 'elro_system_code' in item.conf:
+            if 'elro_unit_code' in item.conf:
+                if 'elro_send' in item.conf:
+                    # Add method to trigger if a button was pressed
+                    item.add_method_trigger(self._send)
+    
+    def _send(self, item, caller=None, source=None, dest=None):
+        if (caller != 'Elro'):
+            # Send informations to server (e.g. "0.0.0.0.1;2;0")
+            self.send("%s;%s;%s" % (item.conf['elro_system_code'], item.conf['elro_unit_code'], int(item())))
+    
+    def send(self, payload, host=None, port=None):
+        
+        # Check if host and/or port was given
+        if host == None:
+            host = self._host
+        if port == None:
+            port = self._port
+        
+        # Create socket
+        s = socket.socket()
+        
+        # Connect to server
+        s.connect((self._host, self._port))
+        
+        # Write payload to server
+        s = s.makefile(mode = "rw")
+        s.write(payload)
+        s.flush()
+        
+        # Close server-connection
+        s.close()


### PR DESCRIPTION
A very simple plugin for connecting to a py_switch_server (https://github.com/Brootux/rc_switch_server.py) for controlling elro (or elro-based) rc-switches.
