### PR TITLE
Configure function registration for SQLite and RRD plugin

### DIFF
--- a/plugins/rrd/README.md
+++ b/plugins/rrd/README.md
@@ -33,10 +33,45 @@ plugin.conf
     class_path = plugins.rrd
     # step = 300
     # rrd_dir = /usr/smarthome/var/rrd/
+    # register = _single : db | _series : series
 </pre>
 
-`step` sets the cycle time how often entries will be updated.
-`rrd_dir` specify the rrd storage location.
+### step
+Sets the cycle time how often entries will be updated.
+
+### rrd_dir
+Specify the directory of the rrd storage.
+
+### register
+Usually this plugin registers function on all items to provide access to the
+data (see below for the details of the function).
+
+This functions can be used in other plugins or logics or other code you're
+using. Since it registers the function on a specific name, you're not able
+to use other plugins, which registers functions with the same name too (e.g.
+the SQLite plugin).
+
+To avoid nameing clashes you can use this configuration setting to register
+the function with another name. To configure this use a hash-map style
+configuration which consits of the original function name and the mapped
+function. The standard configuration is shown above in the example (so no
+special mapping is configured).
+
+For example you can configure the registration the function with other names:
+<pre>
+  register = \_single : rrd_db | \_series : rrd_series
+</pre>
+
+This will register the `_single` function (as shown below) with another name
+`rrd_db` and the function `_series` (internally used in the visu plugin)
+with the name `rrd_series`. You do not need to specify both if you only
+want to use another name for one of the function.
+
+Keep in mind, if you change this, you also need to adjust the code using
+the functions with the standard name. On the other hand, this enables you
+to use both the `sqlite` and the `rrd` plugin, which currently supports
+this.
+
 
 items.conf
 --------------

--- a/plugins/sqlite/README.md
+++ b/plugins/sqlite/README.md
@@ -11,11 +11,46 @@ plugin.conf
     class_path = plugins.sqlite
 #   path = None
 #   dumpfile = /tmp/smarthomedb.dump
+#   register =  _single : db | _series : series
 </pre>
 
-The `path` attribute allows you to specify the of the SQLite database.
+### path
+This attribute allows you to specify the directory of the SQLite database if
+you do not want to use the default directory.
 
+### dumpfile
 If you specify a `dumpfile`, SmartHome.py dumps the database every night into this file.
+
+### register
+Usually this plugin registers function on all items to provide access to the
+data (see below for the details of the function).
+
+This functions can be used in other plugins or logics or other code you're
+using. Since it registers the function on a specific name, you're not able
+to use other plugins, which registers functions with the same name too (e.g.
+the SQLite plugin).
+
+To avoid naming clashes you can use this configuration setting to register
+the function with another name. To configure this use a hash-map style
+configuration which consits of the original function name and the mapped
+function. The standard configuration is shown above in the example (so no
+special mapping is configured).
+
+For example you can configure the registration the function with other names:
+<pre>
+  register = \_single : sqlite_db | \_series : sqlite_series
+</pre>
+
+This will register the `_single` function (as shown below) with another name
+`sqlite_db` and the function `_series` (internally used in the visu plugin)
+with the name `sqlite_series`. You do not need to specify both if you only
+want to use another name for one of the function.
+
+Keep in mind, if you change this, you also need to adjust the code using
+the functions with the standard name. On the other hand, this enables you
+to use both the `sqlite` and the `rrd` plugin, which currently supports
+this.
+
 
 items.conf
 --------------


### PR DESCRIPTION
Currently it's not possible to use the SQLite and RRD plugin at the same time, since it registers two functions
- db()
- series()

to all items having the SQLite or RRD plugin enabled. To make it possible to use both plugins at the same time, you can now use the `register` configuration which configures a map for the function registration of the mentioned functions above.

The default for this would be `register = _single : db | _series : series`, which can be overwritten in one of the plugins to make it possible to the let the other plugin register too.

Keep in mind that the visu plugin is also using the `series()` function, which should be registered by one of the plugin to keep the visu plugin running!

This patch is more a preparation to make it possible to decide which plugin should be used to provide historical data for items (sqlite plugin or rrd plugin when you want running both of them). The next step I want to implement is, to let the `dblog` plugin provide the data too.

This way you're flexible as much as possible since you can decide which plugin you want to use and which plugin you want to provide the historical data. 
