### PR TITLE
Disable / enable logics

### DIFF
--- a/lib/logic.py
+++ b/lib/logic.py
@@ -86,6 +86,7 @@ class Logic():
     def __init__(self, smarthome, name, attributes):
         self._sh = smarthome
         self.name = name
+        self.enabled = True
         self.crontab = None
         self.cycle = None
         self.prio = 3
@@ -103,10 +104,18 @@ class Logic():
         return self.name
 
     def __call__(self, caller='Logic', source=None, value=None, dest=None, dt=None):
-        self._sh.scheduler.trigger(self.name, self, prio=self.prio, by=caller, source=source, dest=dest, value=value, dt=dt)
+        if self.enabled:
+            self._sh.scheduler.trigger(self.name, self, prio=self.prio, by=caller, source=source, dest=dest, value=value, dt=dt)
+
+    def enable(self):
+        self.enabled =True
+
+    def disable(self):
+        self.enabled = False
 
     def trigger(self, by='Logic', source=None, value=None, dest=None, dt=None):
-        self._sh.scheduler.trigger(self.name, self, prio=self.prio, by=by, source=source, dest=dest, value=value, dt=dt)
+        if self.enabled:
+            self._sh.scheduler.trigger(self.name, self, prio=self.prio, by=by, source=source, dest=dest, value=value, dt=dt)
 
     def generate_bytecode(self):
         if hasattr(self, 'filename'):

--- a/lib/scheduler.py
+++ b/lib/scheduler.py
@@ -338,7 +338,8 @@ class Scheduler(threading.Thread):
             logic = obj  # noqa
             sh = self._sh  # noqa
             try:
-                exec(obj.bytecode)
+                if logic.enabled:
+                    exec(obj.bytecode)
             except SystemExit:
                 # ignore exit() call from logic.
                 pass

--- a/plugins/cli/README.md
+++ b/plugins/cli/README.md
@@ -34,6 +34,8 @@ lt: list current thread names
 update item = value: update the specified item with the specified value
 up: alias for update
 tr logic: trigger logic
+el logic: enables logic
+dl logic: disables logic
 rl logic: reload logic
 rr logic: reload and run logic
 quit: quit the session

--- a/plugins/cli/__init__.py
+++ b/plugins/cli/__init__.py
@@ -171,8 +171,7 @@ class CLIHandler(lib.connection.Stream):
 
     def lo(self):
         self.push("Logics:\n")
-        try:
-         for logic in sorted(self.sh.return_logics()):
+        for logic in sorted(self.sh.return_logics()):
             data = []
             lo = self.sh.return_logic(logic)
             nt = self.sh.scheduler.return_next(logic)
@@ -184,8 +183,6 @@ class CLIHandler(lib.connection.Stream):
             if len(data):
                 self.push(" ({0})".format(", ".join(data)))
             self.push("\n")
-        except Exception as e:
-            self.push("{}\n".format(e))
 
     def lt(self):
         # list all threads with names

--- a/plugins/visu/__init__.py
+++ b/plugins/visu/__init__.py
@@ -304,10 +304,18 @@ class WebSocketHandler(lib.connection.Stream):
             if 'name' not in data or 'val' not in data:
                 return
             name = data['name']
-            value = data['val']
             if name in self.logics:
-                logger.info("Client {0} triggerd logic {1} with '{2}'".format(self.addr, name, value))
-                self.logics[name].trigger(by='Visu', value=value, source=self.addr)
+                if 'val' in data:
+                    value = data['val']
+                    logger.info("Client {0} triggerd logic {1} with '{2}'".format(self.addr, name, value))
+                    self.logics[name].trigger(by='Visu', value=value, source=self.addr)
+                if 'enabled' in data:
+                    if data['enabled']:
+                        logger.info("Client {0} enabled logic {1}".format(self.addr, name))
+                        self.logics[name].enable()
+                    else:
+                        logger.info("Client {0} disabled logic {1}".format(self.addr, name))
+                        self.logics[name].disable()
             else:
                 logger.warning("Client {0} requested invalid logic: {1}".format(self.addr, name))
         elif command == 'series':


### PR DESCRIPTION
In some cases it makes sense to temporarily disable a given logic and enable later again. At least I would like to disable some logics for some days but enable it again later. And I don't want to comment out the logic and restart SmartHome.py.

This patch contains the following enhancements:
- enable and disable logics with `logic.enable()` and `logic.disable()`
- check enabled status with `logic.enabled` property
- enable and disable logic using `el` and `dl` CLI commands
- show if logic is disabled when using `ll` CLI command
- add posibility to enable and disable logics via visu plugin (using `{ "cmd" : "logic", "name" : "<name>", "enabled" : 0/1 }` - the `val` attribute can also be specified to additionally trigger the logic, as this is the current behaviour)
