### PR TITLE
Attach logic trigger methods for plugins

### DIFF
--- a/lib/logic.py
+++ b/lib/logic.py
@@ -51,7 +51,9 @@ class Logics():
             # plugin hook
             for plugin in self._sh._plugins:
                 if hasattr(plugin, 'parse_logic'):
-                    plugin.parse_logic(logic)
+                    update = plugin.parse_logic(logic)
+                    if update:
+                        logic.add_method_trigger(update)
             # item hook
             if hasattr(logic, 'watch_item'):
                 if isinstance(logic.watch_item, str):
@@ -95,6 +97,7 @@ class Logic():
             vars(self)[attribute] = attributes[attribute]
         self.generate_bytecode()
         self.prio = int(self.prio)
+        self.__methods_to_trigger = []
 
     def id(self):
         return self.name
@@ -121,3 +124,10 @@ class Logic():
                 logger.exception("Exception: {}".format(e))
         else:
             logger.warning("{}: No filename specified => ignoring.".format(self.name))
+
+    def add_method_trigger(self, method):
+        self.__methods_to_trigger.append(method)
+
+    def get_method_triggers(self):
+        return self.__methods_to_trigger
+

--- a/lib/scheduler.py
+++ b/lib/scheduler.py
@@ -339,6 +339,11 @@ class Scheduler(threading.Thread):
             sh = self._sh  # noqa
             try:
                 exec(obj.bytecode)
+                for method in logic.get_method_triggers():
+                    try:
+                        method(logic, by, source, dest)
+                    except Exception as e:
+                        logger.exception("Logic: Tigger {} for {} failed: {}".format(method, logic.name, e))
             except SystemExit:
                 # ignore exit() call from logic.
                 pass
@@ -346,8 +351,6 @@ class Scheduler(threading.Thread):
                 tb = sys.exc_info()[2]
                 tb = traceback.extract_tb(tb)[-1]
                 logger.exception("Logic: {0}, File: {1}, Line: {2}, Method: {3}, Exception: {4}".format(name, tb[0], tb[1], tb[2], e))
-            for method in logic.get_method_triggers():
-                method(logic, by, source, dest)
         elif obj.__class__.__name__ == 'Item':
             try:
                 if value is not None:

--- a/lib/scheduler.py
+++ b/lib/scheduler.py
@@ -346,6 +346,8 @@ class Scheduler(threading.Thread):
                 tb = sys.exc_info()[2]
                 tb = traceback.extract_tb(tb)[-1]
                 logger.exception("Logic: {0}, File: {1}, Line: {2}, Method: {3}, Exception: {4}".format(name, tb[0], tb[1], tb[2], e))
+            for method in logic.get_method_triggers():
+                method(logic, by, source, dest)
         elif obj.__class__.__name__ == 'Item':
             try:
                 if value is not None:


### PR DESCRIPTION
Plugin developers have two possibilities to attach the logic to the SmartHome.py configuration / system:
- using `parse_item()` method
- using `parse_logic()` method

The `parse_item()` method is called for each configured item and the plugin can decide if it is interested in item changes or not by simply returning an update method depending on the condition. When returning an update method a trigger method will be added to the item and invoked each time the item's value is changed.

The `parse_logic()` method is called for each configured logic and the plugin can decide if it is interested in the logic or not. This can be used to setup some configuration for the plugin, but can't be used to register a trigger method which is invoked each time the logic is triggered. This patch add this functionality to register a trigger method for logics by simply returning a trigger method.

Example:

```
  def parse_item(self, item):
      ...
      return self.update_item

  def parse_logic(self, logic):
      ...
      return self.trigger_logic

  def update_item(self, item, caller=None, source=None, dest=None):
      // do something on item value change
      ...

   def trigger_logic(self, logic, by=None, source=None, dest=None):
      // do something on logic trigger
      ...
```

This way a plugin can register a logic hook, which is called each time a logic was triggered.
