### PR TITLE
CLI: Scheduler commands

### DIFF
--- a/plugins/cli/__init__.py
+++ b/plugins/cli/__init__.py
@@ -168,12 +168,16 @@ class CLIHandler(lib.connection.Stream):
 
     def sl(self):
         logics = sorted(self.sh.return_logics())
-        self.push("Scheduler tasks:\n")
-        for task in sorted(self.sh.scheduler):
-            if task not in logics:
-                nt = self.sh.scheduler.return_next(task)
-                if nt is not None:
-                    self.push("{0} (scheduled for {1})\n".format(task, nt.strftime('%Y-%m-%d %H:%M:%S%z')))
+        tasks = []
+        for name in sorted(self.sh.scheduler):
+            nt = self.sh.scheduler.return_next(name)
+            if name not in logics and nt is not None:
+                task = { 'nt' : nt, 'name' : name }
+                tasks.append(task)
+
+        self.push("{} scheduler tasks:\n".format(len(tasks)))
+        for task in tasks:
+            self.push("{0} (scheduled for {1})\n".format(task['name'], task['nt'].strftime('%Y-%m-%d %H:%M:%S%z')))
 
     def st(self):
         logics = sorted(self.sh.return_logics())
@@ -189,7 +193,7 @@ class CLIHandler(lib.connection.Stream):
                         break
                 tasks.insert(p, task)
 
-        self.push("Scheduler tasks by time:\n")
+        self.push("{} scheduler tasks by time:\n".format(len(tasks)))
         for task in tasks:
             self.push("{0} {1}\n".format(task['nt'].strftime('%Y-%m-%d %H:%M:%S%z'), task['name']))
 

--- a/plugins/cli/__init__.py
+++ b/plugins/cli/__init__.py
@@ -66,6 +66,10 @@ class CLIHandler(lib.connection.Stream):
             self.rr(cmd.lstrip('rr').strip())
         elif cmd == 'rt' or cmd == 'runtime':
             self.rt()
+        elif cmd == 'sl':
+            self.sl()
+        elif cmd == 'st':
+            self.st()
         elif cmd == 'help' or cmd == 'h':
             self.usage()
         elif cmd in ('quit', 'q', 'exit', 'x'):
@@ -162,6 +166,33 @@ class CLIHandler(lib.connection.Stream):
         for t in threading.enumerate():
             self.push("{0}\n".format(t.name))
 
+    def sl(self):
+        logics = sorted(self.sh.return_logics())
+        self.push("Scheduler tasks:\n")
+        for task in sorted(self.sh.scheduler):
+            if task not in logics:
+                nt = self.sh.scheduler.return_next(task)
+                if nt is not None:
+                    self.push("{0} (scheduled for {1})\n".format(task, nt.strftime('%Y-%m-%d %H:%M:%S%z')))
+
+    def st(self):
+        logics = sorted(self.sh.return_logics())
+        tasks = []
+        for name in sorted(self.sh.scheduler):
+            nt = self.sh.scheduler.return_next(name)
+            if name not in logics and nt is not None:
+                task = { 'nt' : nt, 'name' : name }
+                p = len(tasks)
+                for i in range(0, len(tasks)):
+                    if nt < tasks[i]['nt']:
+                        p = i
+                        break
+                tasks.insert(p, task)
+
+        self.push("Scheduler tasks by time:\n")
+        for task in tasks:
+            self.push("{0} {1}\n".format(task['nt'].strftime('%Y-%m-%d %H:%M:%S%z'), task['name']))
+
     def rt(self):
         # return SH.py runtime
         self.push("Runtime: {}\n".format(self.sh.runtime()))
@@ -179,6 +210,8 @@ class CLIHandler(lib.connection.Stream):
         self.push('rl logic: reload logic\n')
         self.push('rr logic: reload and run logic\n')
         self.push('rt: return runtime\n')
+        self.push('sl: list all scheduler tasks by name\n')
+        self.push('st: list all scheduler tasks by execution time\n')
         self.push('quit: quit the session\n')
         self.push('q: alias for quit\n')
 

--- a/plugins/cli/__init__.py
+++ b/plugins/cli/__init__.py
@@ -66,6 +66,8 @@ class CLIHandler(lib.connection.Stream):
             self.rr(cmd.lstrip('rr').strip())
         elif cmd == 'rt' or cmd == 'runtime':
             self.rt()
+        elif cmd.startswith('si'):
+            self.si(cmd.lstrip('si').strip())
         elif cmd == 'sl':
             self.sl()
         elif cmd == 'st':
@@ -166,6 +168,17 @@ class CLIHandler(lib.connection.Stream):
         for t in threading.enumerate():
             self.push("{0}\n".format(t.name))
 
+    def si(self, name):
+        if name not in self.sh.scheduler._scheduler:
+            self.push("Scheduler task '{}' not found\n".format(name))
+        else:
+            task = self.sh.scheduler._scheduler[name]
+            self.push("Task {} ".format(name))
+            self.push("{\n")
+            for key in task:
+                self.push("  {} = {}\n".format(key, task[key]))
+            self.push("}\n")
+
     def sl(self):
         logics = sorted(self.sh.return_logics())
         tasks = []
@@ -214,6 +227,7 @@ class CLIHandler(lib.connection.Stream):
         self.push('rl logic: reload logic\n')
         self.push('rr logic: reload and run logic\n')
         self.push('rt: return runtime\n')
+        self.push('si task: show details for given task\n')
         self.push('sl: list all scheduler tasks by name\n')
         self.push('st: list all scheduler tasks by execution time\n')
         self.push('quit: quit the session\n')


### PR DESCRIPTION
Added two new scheduler commands to list scheduled tasks (but not logics, which are already listed by other commands):
- `sl` - list all tasks with a scheduled ordered by name
- `st` - list all tasks with a scheduled ordered by next execution time
- `si` - show information for given scheduler task

Example output for `sl`:

```
> sl
3 scheduler tasks:
Connections (scheduled for 2015-02-17 13:12:49+0100)
series (scheduled for 2015-02-17 13:12:49+0100)
sh.gc (scheduled for 2015-02-18 02:04:00+0100)
> 
```

Example output for `st`:

```
> st
3 scheduler tasks by time:
2015-02-17 13:33:29+0100 Connections
2015-02-17 13:33:29+0100 series
2015-02-18 02:04:00+0100 sh.gc
> 

```

Example output for `si`:

```
> si sh.gc
Task sh.gc {
  obj = <bound method SmartHome._maintenance of <__main__.SmartHome object at 0xe213b0>>
  prio = 8
  value = None
  next = 2015-03-23 02:04:00+01:00
  cron = {'4 2 * *': None}
  active = True
  cycle = None
}
> 
```
