### PR TITLE
Support for item.eval = "max"/"min"

### DIFF
--- a/lib/item.py
+++ b/lib/item.py
@@ -316,6 +316,10 @@ class Item():
                     self._eval = ' + '.join(items)
                 elif self._eval == 'avg':
                     self._eval = '({0})/{1}'.format(' + '.join(items), len(items))
+                elif self._eval == 'max':
+                    self._eval = 'max({0})'.format(','.join(items))
+                elif self._eval = 'min':
+                    self._eval = 'min({0})'.format(','.join(items))
 
     def _init_run(self):
         if self._eval_trigger:


### PR DESCRIPTION
I required items that hold the min/max value of a series of other items. eval is a perfect solution for such a requirement but didn't support min/max, yet. So I added this "feature" ...