### PR TITLE
Be able to change dicts/lists via CLI plugin

### DIFF
--- a/lib/item.py
+++ b/lib/item.py
@@ -24,6 +24,7 @@ import logging
 import os
 import pickle
 import threading
+import json
 
 logger = logging.getLogger('')
 
@@ -40,6 +41,8 @@ def _cast_str(value):
 
 
 def _cast_list(value):
+    if isinstance(value, str):
+        value = json.loads(value)
     if isinstance(value, list):
         return value
     else:
@@ -47,6 +50,8 @@ def _cast_list(value):
 
 
 def _cast_dict(value):
+    if isinstance(value, str):
+        value = json.loads(value)
     if isinstance(value, dict):
         return value
     else:


### PR DESCRIPTION
Currently only simple types (like str, int, ...) can be changed by the CLI plugin's `up` command. This patch add support for updating items with the type `dict` and `list` by using the following commands:

```
> ls test.dict
Items:
======
test.dict = {}
> up test.dict = { "key1" : "value1", "key2" : 2 }
> ls test.dict
Items:
======
test.dict = {'key2': 2, 'key1': 'value1'}
> 
```

```
> ls test.list
Items:
======
test.list = []
> up test.list = [ 1, 2, 3, "foo", "bar" ]
> ls test.list
Items:
======
test.list = [1, 2, 3, 'foo', 'bar']
> 
```

The implementation is using `json.loads()` method, which converts the string value and then try to update with the resulting value. So passing a wrong syntax or wrong structure type will end in the
`Item test.dict: value ... does not match type dict. Via CLI ...`
error.

Since it is implemented directly in the item's cast functions, all places updating the item values can now also use a string value for item of type dict/list. This could be a drawback and was not really inteted by this patch, but could on the other side be a handy feature.
