### PR TITLE
Remove trigger from items

### DIFF
--- a/lib/item.py
+++ b/lib/item.py
@@ -399,8 +399,14 @@ class Item():
     def add_logic_trigger(self, logic):
         self.__logics_to_trigger.append(logic)
 
+    def remove_logic_trigger(self, logic):
+        self.__logics_to_trigger.remove(logic)
+
     def add_method_trigger(self, method):
         self.__methods_to_trigger.append(method)
+
+    def remove_method_trigger(self, method):
+        self.__methods_to_trigger.remove(method)
 
     def age(self):
         delta = self._sh.now() - self.__last_change


### PR DESCRIPTION
The current implementation about item triggers offers only methods to add triggers to an item (e.g. update trigger or logic trigger).

This patch adds to methods to remove the trigger again:
- `remove_method_trigger()`
- `remove_logic_trigger()`

This way a logic developer (for example) has the posibility to dynamically register a trigger and unregister them later again if the logic completes.

Maybe there are other situation where unregistering a trigger is useful (e.g. when reloading some configuration - which is currently not really supported, but may be supported in future versions).
