### PR TITLE
Line continuation in config files

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -43,9 +43,13 @@ def parse(filename, config=None):
     with open(filename, 'r', encoding='UTF-8') as f:
         linenu = 0
         parent = collections.OrderedDict()
-        for raw in f.readlines():
+        lines = iter(f.readlines())
+        for raw in lines:
             linenu += 1
             line = raw.lstrip('\ufeff')  # remove BOM
+            while line.rstrip().endswith('\\'):
+                linenu += 1
+                line = line.rstrip().rstrip('\\') + next(lines, '').lstrip()
             line = line.partition('#')[0].strip()
             if line is '':
                 continue


### PR DESCRIPTION
Some configuration options may get long values assigned (e.g. the eval or trigger settings). These long values are not very comfortable to be edited in an editor since the complete line is not shown.

To ease editing of these long values this patch introduces a continuation character (`\`) which can be used at the end of the line to indicate the following line should be appended.

```
[some_logic_configuration]
  filename = logic-script.py
  watch_item = \
    path.to.item|\
    path.to.item.child|\
    path.to.otheritem|\
    path.to.otheritem.child
```
