### PR TITLE
Add method to get instance of plugin

### DIFF
--- a/bin/smarthome.py
+++ b/bin/smarthome.py
@@ -438,6 +438,12 @@ class SmartHome():
         for plugin in self._plugins:
             yield plugin
 
+    def return_plugin(self, name):
+        for plugin in self._plugins:
+            if plugin.__class__.__name__ == name:
+                return plugin
+        return None
+
     #################################################################
     # Logic Methods
     #################################################################


### PR DESCRIPTION
In order to access methods of plugins it is required to have a method which returns the instance of a certain plugin. Allthough the "return_plugins" method can be used to iterate over all plugins a more convenient method would return the instance of a named plugin.

With this pull request a new method "return_plugin" is added which returns either the instance of the given plugin or None of no matching plugin is found.
The plugin to return needs to be given using it's main class name (e.g. "CLI" for the cli plugin.)
