### PR TITLE
CLI Plugin: Allow other plugins to add custom commands

### DIFF
--- a/plugins/cli/__init__.py
+++ b/plugins/cli/__init__.py
@@ -222,5 +222,9 @@ class CLI(lib.connection.Server):
     def add_command(self, command, function, usage):
         self.additional_commands[command] = {'function': function, 'usage': usage}
 
+    def remove_command(self, command):
+        if command in self.additional_commands:
+            del self.additional_commands[command]
+
     def ping(self, handler, parameter):
         handler.push("pong: {0}\n".format(parameter))


### PR DESCRIPTION
There are already severy pull requests which add additional commands to the CLI plugin. I would also like to be able to trigger some functionality in my own plugin via the CLI plugin. 

This pull requests enhances the CLI plugin with a method to add custom commands. This method can be used by any other plugin. An example is already contained in the modified CLI-plugin.

In order to access the CLI plugin from other plugins, please see my previous pull request #181 which adds a method to get the plugin instance.
