### PR TITLE
OperationLog: initial commit of a new plugin to create logs

### DIFF
--- a/plugins/operationlog/AutoBlindLoggerOLog.py
+++ b/plugins/operationlog/AutoBlindLoggerOLog.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# vim: set encoding=utf-8 tabstop=4 softtabstop=4 shiftwidth=4 expandtab
+#########################################################################
+#  Copyright 2014-2016 Thomas Ernst                       offline@gmx.net
+#########################################################################
+#
+#  Modified version used as parent class for OperationLogger
+#  2016 Jan Troelsen
+#
+#  This file is part of SmartHome.py.
+#
+#  SmartHome.py is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SmartHome.py is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SmartHome.py. If not, see <http://www.gnu.org/licenses/>.
+#########################################################################
+#
+# AutoBlindLoggerOLog
+#
+# Extended logging functionality for debugging AutoBlind plugin
+# Enables to log into different files (e.g. depending on item, room or
+# similar)
+#########################################################################
+import logging
+import datetime
+import os
+
+logger = logging.getLogger("")
+
+
+class AbLogger:
+    # Log-Level: (0=off 1=Info, 2=Debug)
+    __loglevel = 2
+
+    # Target directory for log files
+    __logdirectory = "/usr/local/smarthome/var/log/AutoBlind/"
+
+    # Max age for log files (days)
+    __logmaxage = 0
+
+    # Set log level
+    # loglevel: current loglevel
+    @staticmethod
+    def set_loglevel(loglevel):
+        try:
+            AbLogger.__loglevel = int(loglevel)
+        except ValueError:
+            AbLogger.__loglevel = 2
+            logger.error("Das Log-Level muss numerisch angegeben werden.")
+
+    # Set log directory
+    # logdirectory: Target directory for AutoBlind log files
+    @staticmethod
+    def set_logdirectory(logdirectory):
+        AbLogger.__logdirectory = logdirectory
+
+    # Set max age for log files
+    # logmaxage: Maximum age for log files (days)
+    @staticmethod
+    def set_logmaxage(logmaxage):
+        try:
+            AbLogger.__logmaxage = int(logmaxage)
+        except ValueError:
+            AbLogger.__logmaxage = 0
+            logger.error("Das maximale Alter der Logdateien muss numerisch angegeben werden.")
+
+    @staticmethod
+    def remove_old_logfiles():
+        if AbLogger.__logmaxage == 0:
+            return
+        logger.info("Removing logfiles older than {0} days".format(AbLogger.__logmaxage))
+        count_success = 0
+        count_error = 0
+        now = datetime.datetime.now()
+        for file in os.listdir(AbLogger.__logdirectory):
+            if file.endswith(".log"):
+                try:
+                    abs_file = os.path.join(AbLogger.__logdirectory, file)
+                    stat = os.stat(abs_file)
+                    mtime = datetime.datetime.fromtimestamp(stat.st_mtime)
+                    age_in_days = (now - mtime).total_seconds() / 86400.0
+                    if age_in_days > AbLogger.__logmaxage:
+                        os.unlink(abs_file)
+                        count_success += 1
+                except Exception as ex:
+                    logger.error(str(ex))
+                    count_error += 1
+        logger.info("{0} files removed, {1} errors occured".format(count_success, count_error))
+
+    # Return AbLogger instance for given item
+    # item: item for which the detailed log is
+    @staticmethod
+    def create(item):
+        return AbLogger(item)
+
+    # Constructor
+    # item: item for which the detailed log is (used as part of file name)
+    def __init__(self, item):
+        try:
+            self.__section = item.id().replace(".", "_").replace("/", "")
+        except (AttributeError, TypeError):
+            # parameter is no item, use as text instead
+            self.__section = str(item).replace(".", "_").replace("/", "")
+        self.__indentlevel = 0
+        self.__date = None
+        self.__filename = ""
+
+    # Update name logfile if required
+    def update_logfile(self, name=None):
+        if isinstance(name, type(None)):
+            if self.__date == datetime.datetime.today() and self.__filename is not None:
+                return
+            self.__date = str(datetime.date.today())
+            self.__filename = str(AbLogger.__logdirectory + self.__date + '-' + self.__section + ".log")
+        else:
+            self.__filename = str(AbLogger.__logdirectory + name)
+
+    # Increase indentation level
+    # by: number of levels to increase
+    def increase_indent(self, by=1):
+        self.__indentlevel += by
+
+    # Decrease indentation level
+    # by: number of levels to decrease
+    def decrease_indent(self, by=1):
+        if self.__indentlevel > by:
+            self.__indentlevel -= by
+        else:
+            self.__indentlevel = 0
+
+    # log text something
+    # level: required loglevel
+    # text: text to log
+    def log(self, level, text, *args):
+        # Section givn: Check level
+        if level <= AbLogger.__loglevel:
+            indent = "\t" * self.__indentlevel
+            text = text.format(*args)
+            logtext = "{0}{1} {2}\r\n".format(datetime.datetime.now(), indent, text)
+            with open(self.__filename, mode="a", encoding="utf-8") as f:
+                f.write(logtext)
+            # JT
+            logger.debug("Writing: {} to logfile: {}".format(logtext, self.__filename))
+
+    # log header line (as info)
+    # text: header text
+    def header(self, text):
+        self.__indentlevel = 0
+        text += " "
+        self.log(1, text.ljust(80, "="))
+
+    # log with level=info
+    # @param text text to log
+    # @param *args parameters for text
+    def info(self, text, *args):
+        self.log(1, text, *args)
+
+    # log with lebel=debug
+    # text: text to log
+    # *args: parameters for text
+    def debug(self, text, *args):
+        self.log(2, text, *args)
+
+    # log warning (always to main smarthome.py log)
+    # text: text to log
+    # *args: parameters for text
+    # noinspection PyMethodMayBeStatic
+    def warning(self, text, *args):
+        self.log(1, "WARNING: " + text, *args)
+        logger.warning(text.format(*args))
+
+    # log error (always to main smarthome.py log)
+    # text: text to log
+    # *args: parameters for text
+    # noinspection PyMethodMayBeStatic
+    def error(self, text, *args):
+        self.log(1, "ERROR: " + text, *args)
+        logger.error(text.format(*args))
+
+    # log exception (always to main smarthome.py log'
+    # msg: message to log
+    # *args: arguments for message
+    # **kwargs: known arguments for message
+    # noinspection PyMethodMayBeStatic
+    def exception(self, msg, *args, **kwargs):
+        self.log(1, "EXCEPTION: " + msg, *args)
+        logger.exception(msg, *args, **kwargs)

--- a/plugins/operationlog/README.md
+++ b/plugins/operationlog/README.md
@@ -1,0 +1,83 @@
+# OperationLog
+
+This plugins can be used to create logs which are cached, written to file and stored in memory to be used by items or other
+plugins. Furthermore the logs can be visualised by smartVISU using the standard widget "status.log".
+
+# Requirements
+
+No special requirements.
+
+# Configuration
+
+## plugin.conf
+
+Use the plugin configuration to configure the logs.
+
+<pre>
+[mylogname1]
+   class_name = OperationLog
+   class_path = plugins.operationlog
+   name = mylogname1
+#   maxlen = 50
+#   cache = yes
+#   logtofile = yes
+#   filepattern = {year:04}-{month:02}-{day:02}-{name}.log
+
+
+
+[mylogname2]
+   class_name = OperationLog
+   class_path = plugins.operationlog
+   name = mylogname2
+   maxlen = 0
+   cache = no
+   logtofile = yes
+   filepattern = yearly_log-{name}-{year:04}.log
+
+   ...
+</pre>
+
+This will register two logs named mylogname1 and mylogname2. The first one named mylogname1 is configured with the default configuration as shown, caching the log to file (smarthome/var/cache/mylogname1) and logging to file (smarthome/var/log/operationlog/yyyy-mm-dd-mylogname1.log). Every day a new logfile will be created. The last 50 entries will be kept in memory.
+
+The entries of the second log will not be kept in memory, only logged to a yearly file with the pattern yearly_log-mylogname2-yyyy.  
+
+## items
+Configure an item to be logged as follows:
+
+<pre>
+[foo]
+    [[bar]]
+        type = num
+        olog = mylogname1
+        olog_level = ERROR
+</pre> 
+
+When the item gets updated a new log entry using loglevel 'ERROR' will be generated in the log mylogname1. The format of the entry will be "foo.bar = value". Item types num, bool and str can be used.
+
+## Functions
+
+<pre>
+sh.mylogname1('level_keyword', msg)
+</pre>
+
+Logs the message in `msg` parameter with the given log level specified in the `level_keyword` parameter. 
+
+Using the loglevel keywords 'INFO', 'WARNING' and 'ERROR' (upper or lower case) will cause the smartVISU plugin "status.log" to mark the entries with the colors green, yellow and red respectively. Alternative formulation causing a red color are 'EXCEPTION' and 'CRITICAL'. Using other loglevel keyword will result in log entry without a color mark.
+
+<pre>
+sh.mylogname1(msg)
+</pre>
+
+Logs the message in the `msg` parameter with the default loglevel 'INFO'.
+
+ <pre>
+data = sh.mylogname1()
+</pre>
+
+will return a deque object containing the log with the last `maxlen` entries.
+
+
+
+
+
+This plugin is inspired from the plugins MemLog and AutoBlind, reusing some of their sourcecode.

--- a/plugins/operationlog/__init__.py
+++ b/plugins/operationlog/__init__.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+#########################################################################
+# Copyright 2016 Jan Troelsen                             jan@troelsen.de
+#########################################################################
+#  operationlogger
+#
+#  SmartHome.py is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SmartHome.py is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SmartHome.py. If not, see <http://www.gnu.org/licenses/>.
+#########################################################################
+
+import logging
+import threading
+import datetime
+import lib.log
+import os
+import pickle
+
+from .AutoBlindLoggerOLog import AbLogger
+
+logger = logging.getLogger('')
+
+
+class OperationLog(AbLogger):
+    _log = None
+    _items = {}
+
+    def __init__(self, smarthome, name, cache=True, logtofile=True, filepattern="{year:04}-{month:02}-{day:02}-{name}.log", 
+                 mapping=['time', 'thread', 'level', 'message'],items=[], maxlen=50):
+        log_directory = "var/log/operationlog/"
+        self._sh = smarthome
+        self.name = name
+        if log_directory[0] != "/":
+            base = self._sh.base_dir
+            if base[-1] != "/":
+                base += "/"
+            self.log_directory = base + log_directory
+        else:
+            self.log_directory = log_directory
+        if not os.path.exists(self.log_directory):
+            os.makedirs(log_directory)
+        AbLogger.set_logdirectory(self.log_directory)
+        AbLogger.set_loglevel(2)
+        AbLogger.set_logmaxage(0)
+        AbLogger.__init__(self, name)
+        self._filepattern = filepattern
+        self._log = lib.log.Log(smarthome, name, mapping, int(maxlen))
+        self._path = name
+        self._cachefile = None
+        self._cache = True
+        self.__myLogger = None
+        self._logcache = None
+        self._maxlen = maxlen
+        self._items = items
+        self.__date = None
+        self.__fname = None
+        info_txt_cache = ", caching active"
+        if isinstance(cache, str) and cache in ['False', 'false', 'No', 'no']:
+            self._cache = False
+            info_txt_cache = ""
+        self._logtofile = True
+        info_txt_log = "OperationLog {}: logging to file {}{}, keeping {} entries in memory".format(self.name, self.log_directory,
+                                                                                                     self._filepattern, self._maxlen)
+        if isinstance(logtofile, str) and logtofile in ['False', 'false', 'No', 'no']:
+            self._logtofile = False
+        logger.info(info_txt_log + info_txt_cache)
+
+        #############################################################
+        # Cache
+        #############################################################
+        if self._cache is True:
+            self._cachefile = self._sh._cache_dir + self._path
+            try:
+                self.__last_change, self._logcache = _cache_read(self._cachefile, self._sh._tzinfo)
+                self.load(self._logcache)
+                logger.debug("OperationLog {}: read cache: {}".format(self.name, self._logcache))
+            except Exception:
+                try:
+                    _cache_write(self._cachefile, self._log.export(self._maxlen))
+                    _cache_read(self._cachefile, self._sh._tzinfo)
+                    logger.info("OperationLog {}: generated cache file".format(self.name))
+                except Exception as e:
+                    logger.warning("OperationLog {}: problem reading cache: {}".format(self._path, e))
+
+    def update_logfilename(self):
+        if self.__date == datetime.datetime.today() and self.__fname is not None:
+            return
+        now = self._sh.now()
+        self.__fname = self._filepattern.format(**{'name': self.name, 'year': now.year, 'month': now.month, 'day': now.day})
+        self.__myLogger.update_logfile(self.__fname)
+
+    def run(self):
+        if self._logtofile is True:
+            self.__myLogger = self.create(self.name)
+        self.alive = True
+
+    def stop(self):
+        self.alive = False
+
+    def parse_item(self, item):
+        if 'olog' in item.conf and item.conf['olog'] == self.name:
+            return self.update_item
+        else:
+            return None
+
+    def parse_logic(self, logic):
+        pass
+
+    def __call__(self, param1=None, param2=None):
+        if isinstance(param1, list) and isinstance(param2, type(None)):
+            self.log(param1)
+        elif isinstance(param1, str) and isinstance(param2, type(None)):
+            self.log([param1])
+        elif isinstance(param1, str) and isinstance(param2, str):
+            self.log([param2], param1)
+        elif isinstance(param1, type(None)) and isinstance(param2, type(None)):
+            return self._log
+
+        if self._cache is True:
+            try:
+                _cache_write(self._cachefile, self._log.export(self._maxlen))
+            except Exception as e:
+                logger.warning("OperationLog {}: could not update cache {}".format(self._path, e))
+
+    def load(self, logentries):
+        if len(logentries) != 0:
+            for logentry in reversed(logentries):
+                log = []
+                for name in self._log.mapping:
+                    if name == 'time':
+                        log.append(logentry['time'])
+                    elif name == 'thread':
+                        log.append(logentry['thread'])
+                    elif name == 'level':
+                        log.append(logentry['level'])
+                    elif name == 'message':
+                        log.append(logentry['message'])
+                self._log.add(log)
+
+    def update_item(self, item, caller=None, source=None, dest=None):
+        if caller != 'OperationLog':
+            if item.conf['olog'] == self.name:
+                if len(self._items) == 0:
+                    logvalues = [item.id(), '=', item()]
+                else:
+                    logvalues = []
+                    for it in self._items:
+                        logvalues.append('{} = {} '.format(str(it), self._sh.return_item(it)()))
+                self.log(logvalues, 'INFO' if not item.conf['olog_level'] else item.conf['olog_level'])
+
+    def log(self, logvalues, level='INFO'):
+        if len(logvalues):
+            log = []
+            for name in self._log.mapping:
+                if name == 'time':
+                    log.append(self._sh.now())
+                elif name == 'thread':
+                    log.append(threading.current_thread().name)
+                elif name == 'level':
+                    log.append(level)
+                else:
+                    values_txt = map(str, logvalues)
+                    log.append(' '.join(values_txt))
+            self._log.add(log)
+            if self._logtofile is True:
+                self.update_logfilename()
+                self.__myLogger.info('{}: {}', log[2], ''.join(log[3:]))
+
+
+#####################################################################
+# Cache Methods
+#####################################################################
+def _cache_read(filename, tz):
+    ts = os.path.getmtime(filename)
+    dt = datetime.datetime.fromtimestamp(ts, tz)
+    value = None
+    with open(filename, 'rb') as f:
+        value = pickle.load(f)
+    return (dt, value)
+
+
+def _cache_write(filename, value):
+    try:
+        with open(filename, 'wb') as f:
+            pickle.dump(value, f)
+    except IOError:
+        logger.warning("Could not write to {}".format(filename))


### PR DESCRIPTION
This plugins can be used to create logs which are cached, written to file
and stored in memory to be used by items or other plugins. Furthermore the
logs can be visualised by smartVISU using the standard widget "status.log".
